### PR TITLE
fix: Windows用のワークアラウンドを削除

### DIFF
--- a/Sources/KanaKanjiConverterModule/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/Zenz.swift
@@ -15,9 +15,6 @@ import EfficientNGram
                 // this is not percent-encoded
                 self.zenzContext = try ZenzContext.createContext(path: resourceURL.path)
             }
-#elseif canImport(WinSDK)
-            // remove first "/" from path (for windows)
-            self.zenzContext = try ZenzContext.createContext(path: String(resourceURL.path.dropFirst()))
 #else
             // this is not percent-encoded
             self.zenzContext = try ZenzContext.createContext(path: resourceURL.path)


### PR DESCRIPTION
 (https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/122) を削除

Swiftのアップデートで挙動が修正されたため