### PR TITLE
feat: Add time expression conversion function

### DIFF
--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -1,7 +1,14 @@
+//
+//  KanaKanjiConverter.swift
+//  AzooKeyKanaKanjiConverter
+//
+//  Created by ensan on 2020/09/03.
+//  Copyright © 2020 ensan. All rights reserved.
+//
+
 import Foundation
 import SwiftUtils
 import EfficientNGram
-import TimeExpression
 
 /// かな漢字変換の管理を受け持つクラス
 @MainActor public final class KanaKanjiConverter {
@@ -149,7 +156,7 @@ import TimeExpression
             result.append(contentsOf: self.unicodeCandidates(inputData))
         }
         result.append(contentsOf: self.toVersionCandidate(inputData, options: options))
-        result.append(contentsOf: self.toTimeExpressionCandidates(inputData))
+        result.append(contentsOf: self.convertToTimeExpression(inputData))
         return result
     }
 
@@ -779,12 +786,5 @@ import TimeExpression
         let zeroHints = self.getUniquePostCompositionPredictionCandidate(zeroHintResults, seenCandidates: seenCandidates)
         results.append(contentsOf: zeroHints.min(count: 10 - results.count, sortedBy: {$0.value > $1.value}))
         return results
-    }
-
-    private func toTimeExpressionCandidates(_ inputData: ComposingText) -> [Candidate] {
-        guard let number = Int(inputData.convertTarget) else {
-            return []
-        }
-        return self.convertToTimeExpression(number)
     }
 }

--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -1,14 +1,7 @@
-//
-//  KanaKanjiConverter.swift
-//  AzooKeyKanaKanjiConverter
-//
-//  Created by ensan on 2020/09/03.
-//  Copyright © 2020 ensan. All rights reserved.
-//
-
 import Foundation
 import SwiftUtils
 import EfficientNGram
+import TimeExpression
 
 /// かな漢字変換の管理を受け持つクラス
 @MainActor public final class KanaKanjiConverter {
@@ -156,6 +149,7 @@ import EfficientNGram
             result.append(contentsOf: self.unicodeCandidates(inputData))
         }
         result.append(contentsOf: self.toVersionCandidate(inputData, options: options))
+        result.append(contentsOf: self.toTimeExpressionCandidates(inputData))
         return result
     }
 
@@ -785,5 +779,12 @@ import EfficientNGram
         let zeroHints = self.getUniquePostCompositionPredictionCandidate(zeroHintResults, seenCandidates: seenCandidates)
         results.append(contentsOf: zeroHints.min(count: 10 - results.count, sortedBy: {$0.value > $1.value}))
         return results
+    }
+
+    private func toTimeExpressionCandidates(_ inputData: ComposingText) -> [Candidate] {
+        guard let number = Int(inputData.convertTarget) else {
+            return []
+        }
+        return self.convertToTimeExpression(number)
     }
 }

--- a/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
@@ -10,7 +10,7 @@ extension KanaKanjiConverter {
         if numberString.count == 3 {
             let firstDigit = Int(numberString.prefix(1))!
             let lastTwoDigits = Int(numberString.suffix(2))!
-            if (0...9).contains(firstDigit) && (0...60).contains(lastTwoDigits) {
+            if (0...9).contains(firstDigit) && (0...59).contains(lastTwoDigits) {
                 let timeExpression = "\(firstDigit):\(String(format: "%02d", lastTwoDigits))"
                 let candidate = Candidate(
                     text: timeExpression,
@@ -22,7 +22,7 @@ extension KanaKanjiConverter {
                 candidates.append(candidate)
             }
         } else if numberString.count == 4 {
-            if (0...12).contains(firstPart) && (0...60).contains(secondPart) {
+            if (0...24).contains(firstPart) && (0...59).contains(secondPart) {
                 let timeExpression = "\(String(format: "%02d", firstPart)):\(String(format: "%02d", secondPart))"
                 let candidate = Candidate(
                     text: timeExpression,

--- a/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
@@ -6,7 +6,7 @@ extension KanaKanjiConverter {
         let numberString = inputData.convertTarget
 
         // Check if all chars are digit.
-        if numberString.contains(where: { !$0.isDigit }) {
+        if numberString.contains(where: { !($0.isNumber && $0.isASCII) }) {
             return []
         }
         if numberString.count == 3 {

--- a/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
@@ -5,6 +5,10 @@ extension KanaKanjiConverter {
         var candidates: [Candidate] = []
         let numberString = inputData.convertTarget
 
+        // Check if all chars are digit.
+        if numberString.contains(where: { !$0.isDigit }) {
+            return []
+        }
         if numberString.count == 3 {
             let firstDigit = Int(numberString.prefix(1))!
             let lastTwoDigits = Int(numberString.suffix(2))!

--- a/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
@@ -4,8 +4,6 @@ extension KanaKanjiConverter {
     func convertToTimeExpression(_ inputData: ComposingText) -> [Candidate] {
         var candidates: [Candidate] = []
         let numberString = inputData.convertTarget
-        let firstPart = Int(numberString.prefix(2))!
-        let secondPart = Int(numberString.suffix(2))!
 
         if numberString.count == 3 {
             let firstDigit = Int(numberString.prefix(1))!
@@ -22,8 +20,10 @@ extension KanaKanjiConverter {
                 candidates.append(candidate)
             }
         } else if numberString.count == 4 {
-            if (0...24).contains(firstPart) && (0...59).contains(secondPart) {
-                let timeExpression = "\(String(format: "%02d", firstPart)):\(String(format: "%02d", secondPart))"
+            let firstTwoDigits = Int(numberString.prefix(2))!
+            let lastTwoDigits = Int(numberString.suffix(2))!
+            if (0...24).contains(firstTwoDigits) && (0...59).contains(lastTwoDigits) {
+                let timeExpression = "\(String(format: "%02d", firstTwoDigits)):\(String(format: "%02d", lastTwoDigits))"
                 let candidate = Candidate(
                     text: timeExpression,
                     value: -10,

--- a/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension KanaKanjiConverter {
+    func convertToTimeExpression(_ inputData: ComposingText) -> [Candidate] {
+        var candidates: [Candidate] = []
+        let numberString = inputData.convertTarget
+        let firstPart = Int(numberString.prefix(2))!
+        let secondPart = Int(numberString.suffix(2))!
+
+        if numberString.count == 3 {
+            let firstDigit = Int(numberString.prefix(1))!
+            let lastTwoDigits = Int(numberString.suffix(2))!
+            if (0...9).contains(firstDigit) && (0...60).contains(lastTwoDigits) {
+                let timeExpression = "\(firstDigit):\(String(format: "%02d", lastTwoDigits))"
+                let candidate = Candidate(
+                    text: timeExpression,
+                    value: -10,
+                    correspondingCount: numberString.count,
+                    lastMid: MIDData.一般.mid,
+                    data: [DicdataElement(word: timeExpression, ruby: numberString, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -10)]
+                )
+                candidates.append(candidate)
+            }
+        } else if numberString.count == 4 {
+            if (0...12).contains(firstPart) && (0...60).contains(secondPart) {
+                let timeExpression = "\(String(format: "%02d", firstPart)):\(String(format: "%02d", secondPart))"
+                let candidate = Candidate(
+                    text: timeExpression,
+                    value: -10,
+                    correspondingCount: numberString.count,
+                    lastMid: MIDData.一般.mid,
+                    data: [DicdataElement(word: timeExpression, ruby: numberString, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -10)]
+                )
+                candidates.append(candidate)
+            }
+        }
+        return candidates
+    }
+}

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -2,71 +2,28 @@ import XCTest
 @testable import KanaKanjiConverterModule
 
 final class TimeExpressionTests: XCTestCase {
+    func makeDirectInput(direct input: String) -> ComposingText {
+        ComposingText(
+            convertTargetCursorPosition: input.count,
+            input: input.map {.init(character: $0, inputStyle: .direct)},
+            convertTarget: input
+        )
+    }
+
     func testConvertToTimeExpression() async throws {
         let converter = await KanaKanjiConverter()
 
         // Test 3-digit numbers
-        XCTAssertEqual(converter.convertToTimeExpression(123).first?.text, "1:23")
-        XCTAssertEqual(converter.convertToTimeExpression(945).first?.text, "9:45")
-        XCTAssertEqual(converter.convertToTimeExpression(760).first?.text, "7:60")
-        XCTAssertTrue(converter.convertToTimeExpression(761).isEmpty) // Invalid minute
+        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "123")).first?.text, "1:23")
+        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "945")).first?.text, "9:45")
+        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "760")).first?.text, "7:60")
+        XCTAssertTrue(converter.convertToTimeExpression(makeDirectInput(direct: "761")).isEmpty) // Invalid minute
 
         // Test 4-digit numbers
-        XCTAssertEqual(converter.convertToTimeExpression(1234).first?.text, "12:34")
-        XCTAssertEqual(converter.convertToTimeExpression(9450).first?.text, "09:45")
-        XCTAssertEqual(converter.convertToTimeExpression(7600).first?.text, "07:60")
-        XCTAssertTrue(converter.convertToTimeExpression(1360).isEmpty) // Invalid hour
-        XCTAssertTrue(converter.convertToTimeExpression(1261).isEmpty) // Invalid minute
-    }
-
-    func testToTimeExpressionCandidates() async throws {
-        let converter = await KanaKanjiConverter()
-        var c = ComposingText()
-        
-        // Test 3-digit numbers
-        c.insertAtCursorPosition("123", inputStyle: .direct)
-        var results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "1:23"}))
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("945", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "9:45"}))
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("760", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "7:60"}))
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("761", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertFalse(results.mainResults.contains(where: {$0.text == "7:61"})) // Invalid minute
-        
-        // Test 4-digit numbers
-        c = ComposingText()
-        c.insertAtCursorPosition("1234", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "12:34"}))
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("9450", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "09:45"}))
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("7600", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "07:60"}))
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("1360", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertFalse(results.mainResults.contains(where: {$0.text == "13:60"})) // Invalid hour
-        
-        c = ComposingText()
-        c.insertAtCursorPosition("1261", inputStyle: .direct)
-        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
-        XCTAssertFalse(results.mainResults.contains(where: {$0.text == "12:61"})) // Invalid minute
+        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "1234")).first?.text, "12:34")
+        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "9450")).first?.text, "09:45")
+        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "7600")).first?.text, "07:60")
+        XCTAssertTrue(converter.convertToTimeExpression(makeDirectInput(direct: "1360")).isEmpty) // Invalid hour
+        XCTAssertTrue(converter.convertToTimeExpression(makeDirectInput(direct: "1261")).isEmpty) // Invalid minute
     }
 }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -17,7 +17,7 @@ final class TimeExpressionTests: XCTestCase {
         let input2 = makeDirectInput(direct: "1234")
         let input3 = makeDirectInput(direct: "999")
         let input4 = makeDirectInput(direct: "1260")
-        let input5 = makeDirectInput(direct: "1360")
+        let input5 = makeDirectInput(direct: "2440")
 
         let candidates1 = await converter.convertToTimeExpression(input1)
         let candidates2 = await converter.convertToTimeExpression(input2)
@@ -34,9 +34,9 @@ final class TimeExpressionTests: XCTestCase {
         XCTAssertEqual(candidates3.count, 1)
         XCTAssertEqual(candidates3.first?.text, "9:99")
 
-        XCTAssertEqual(candidates4.count, 1)
-        XCTAssertEqual(candidates4.first?.text, "12:60")
+        XCTAssertEqual(candidates4.count, 0)
 
-        XCTAssertEqual(candidates5.count, 0)
+        XCTAssertEqual(candidates5.count, 1)
+        XCTAssertEqual(candidates5.first?.text, "24:40")
     }
 }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -14,16 +14,16 @@ final class TimeExpressionTests: XCTestCase {
         let converter = await KanaKanjiConverter()
 
         // Test 3-digit numbers
-        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "123")).first?.text, "1:23")
-        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "945")).first?.text, "9:45")
-        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "760")).first?.text, "7:60")
-        XCTAssertTrue(converter.convertToTimeExpression(makeDirectInput(direct: "761")).isEmpty) // Invalid minute
+        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "123")).first?.text, "1:23")
+        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "945")).first?.text, "9:45")
+        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "760")).first?.text, "7:60")
+        XCTAssertTrue(await converter.convertToTimeExpression(makeDirectInput(direct: "761")).isEmpty) // Invalid minute
 
         // Test 4-digit numbers
-        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "1234")).first?.text, "12:34")
-        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "9450")).first?.text, "09:45")
-        XCTAssertEqual(converter.convertToTimeExpression(makeDirectInput(direct: "7600")).first?.text, "07:60")
-        XCTAssertTrue(converter.convertToTimeExpression(makeDirectInput(direct: "1360")).isEmpty) // Invalid hour
-        XCTAssertTrue(converter.convertToTimeExpression(makeDirectInput(direct: "1261")).isEmpty) // Invalid minute
+        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "1234")).first?.text, "12:34")
+        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "9450")).first?.text, "09:45")
+        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "7600")).first?.text, "07:60")
+        XCTAssertTrue(await converter.convertToTimeExpression(makeDirectInput(direct: "1360")).isEmpty) // Invalid hour
+        XCTAssertTrue(await converter.convertToTimeExpression(makeDirectInput(direct: "1261")).isEmpty) // Invalid minute
     }
 }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import KanaKanjiConverterModule
 
 final class TimeExpressionTests: XCTestCase {
-    func makeDirectInput(direct input: String) -> ComposingText {
+    private func makeDirectInput(direct input: String) -> ComposingText {
         ComposingText(
             convertTargetCursorPosition: input.count,
             input: input.map {.init(character: $0, inputStyle: .direct)},
@@ -18,12 +18,18 @@ final class TimeExpressionTests: XCTestCase {
         let input3 = makeDirectInput(direct: "999")
         let input4 = makeDirectInput(direct: "1260")
         let input5 = makeDirectInput(direct: "2440")
+        let input6 = makeDirectInput(direct: "")
+        let input7 = makeDirectInput(direct: "あいうえ")
+        let input8 = makeDirectInput(direct: "13122")
 
         let candidates1 = await converter.convertToTimeExpression(input1)
         let candidates2 = await converter.convertToTimeExpression(input2)
         let candidates3 = await converter.convertToTimeExpression(input3)
         let candidates4 = await converter.convertToTimeExpression(input4)
         let candidates5 = await converter.convertToTimeExpression(input5)
+        let candidates6 = await converter.convertToTimeExpression(input6)
+        let candidates7 = await converter.convertToTimeExpression(input7)
+        let candidates8 = await converter.convertToTimeExpression(input8)
 
         XCTAssertEqual(candidates1.count, 1)
         XCTAssertEqual(candidates1.first?.text, "1:23")
@@ -31,12 +37,17 @@ final class TimeExpressionTests: XCTestCase {
         XCTAssertEqual(candidates2.count, 1)
         XCTAssertEqual(candidates2.first?.text, "12:34")
 
-        XCTAssertEqual(candidates3.count, 1)
-        XCTAssertEqual(candidates3.first?.text, "9:99")
+        XCTAssertEqual(candidates3.count, 0)
 
         XCTAssertEqual(candidates4.count, 0)
 
         XCTAssertEqual(candidates5.count, 1)
         XCTAssertEqual(candidates5.first?.text, "24:40")
+
+        XCTAssertEqual(candidates6.count, 0)
+
+        XCTAssertEqual(candidates7.count, 0)
+
+        XCTAssertEqual(candidates8.count, 0)
     }
 }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import KanaKanjiConverterModule
+
+final class TimeExpressionTests: XCTestCase {
+    func testConvertToTimeExpression() {
+        let converter = KanaKanjiConverter()
+
+        // Test 3-digit numbers
+        XCTAssertEqual(converter.convertToTimeExpression(123).first?.text, "1:23")
+        XCTAssertEqual(converter.convertToTimeExpression(945).first?.text, "9:45")
+        XCTAssertEqual(converter.convertToTimeExpression(760).first?.text, "7:60")
+        XCTAssertTrue(converter.convertToTimeExpression(761).isEmpty) // Invalid minute
+
+        // Test 4-digit numbers
+        XCTAssertEqual(converter.convertToTimeExpression(1234).first?.text, "12:34")
+        XCTAssertEqual(converter.convertToTimeExpression(9450).first?.text, "09:45")
+        XCTAssertEqual(converter.convertToTimeExpression(7600).first?.text, "07:60")
+        XCTAssertTrue(converter.convertToTimeExpression(1360).isEmpty) // Invalid hour
+        XCTAssertTrue(converter.convertToTimeExpression(1261).isEmpty) // Invalid minute
+    }
+
+    func testToTimeExpressionCandidates() async throws {
+        let converter = KanaKanjiConverter()
+        var c = ComposingText()
+        
+        // Test 3-digit numbers
+        c.insertAtCursorPosition("123", inputStyle: .direct)
+        var results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "1:23"}))
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("945", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "9:45"}))
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("760", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "7:60"}))
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("761", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertFalse(results.mainResults.contains(where: {$0.text == "7:61"})) // Invalid minute
+        
+        // Test 4-digit numbers
+        c = ComposingText()
+        c.insertAtCursorPosition("1234", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "12:34"}))
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("9450", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "09:45"}))
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("7600", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertTrue(results.mainResults.contains(where: {$0.text == "07:60"}))
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("1360", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertFalse(results.mainResults.contains(where: {$0.text == "13:60"})) // Invalid hour
+        
+        c = ComposingText()
+        c.insertAtCursorPosition("1261", inputStyle: .direct)
+        results = await converter.requestCandidates(c, options: ConvertRequestOptions())
+        XCTAssertFalse(results.mainResults.contains(where: {$0.text == "12:61"})) // Invalid minute
+    }
+}

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import KanaKanjiConverterModule
 
 final class TimeExpressionTests: XCTestCase {
-    func testConvertToTimeExpression() {
-        let converter = KanaKanjiConverter()
+    func testConvertToTimeExpression() async throws {
+        let converter = await KanaKanjiConverter()
 
         // Test 3-digit numbers
         XCTAssertEqual(converter.convertToTimeExpression(123).first?.text, "1:23")
@@ -20,7 +20,7 @@ final class TimeExpressionTests: XCTestCase {
     }
 
     func testToTimeExpressionCandidates() async throws {
-        let converter = KanaKanjiConverter()
+        let converter = await KanaKanjiConverter()
         var c = ComposingText()
         
         // Test 3-digit numbers

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -11,19 +11,32 @@ final class TimeExpressionTests: XCTestCase {
     }
 
     func testConvertToTimeExpression() async throws {
-        let converter = await KanaKanjiConverter()
+        let converter = KanaKanjiConverter()
 
-        // Test 3-digit numbers
-        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "123")).first?.text, "1:23")
-        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "945")).first?.text, "9:45")
-        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "760")).first?.text, "7:60")
-        XCTAssertTrue(await converter.convertToTimeExpression(makeDirectInput(direct: "761")).isEmpty) // Invalid minute
+        let input1 = makeDirectInput(direct: "123")
+        let input2 = makeDirectInput(direct: "1234")
+        let input3 = makeDirectInput(direct: "999")
+        let input4 = makeDirectInput(direct: "1260")
+        let input5 = makeDirectInput(direct: "1360")
 
-        // Test 4-digit numbers
-        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "1234")).first?.text, "12:34")
-        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "9450")).first?.text, "09:45")
-        XCTAssertEqual(await converter.convertToTimeExpression(makeDirectInput(direct: "7600")).first?.text, "07:60")
-        XCTAssertTrue(await converter.convertToTimeExpression(makeDirectInput(direct: "1360")).isEmpty) // Invalid hour
-        XCTAssertTrue(await converter.convertToTimeExpression(makeDirectInput(direct: "1261")).isEmpty) // Invalid minute
+        let candidates1 = await converter.convertToTimeExpression(input1)
+        let candidates2 = await converter.convertToTimeExpression(input2)
+        let candidates3 = await converter.convertToTimeExpression(input3)
+        let candidates4 = await converter.convertToTimeExpression(input4)
+        let candidates5 = await converter.convertToTimeExpression(input5)
+
+        XCTAssertEqual(candidates1.count, 1)
+        XCTAssertEqual(candidates1.first?.text, "1:23")
+
+        XCTAssertEqual(candidates2.count, 1)
+        XCTAssertEqual(candidates2.first?.text, "12:34")
+
+        XCTAssertEqual(candidates3.count, 1)
+        XCTAssertEqual(candidates3.first?.text, "9:99")
+
+        XCTAssertEqual(candidates4.count, 1)
+        XCTAssertEqual(candidates4.first?.text, "12:60")
+
+        XCTAssertEqual(candidates5.count, 0)
     }
 }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift
@@ -11,7 +11,7 @@ final class TimeExpressionTests: XCTestCase {
     }
 
     func testConvertToTimeExpression() async throws {
-        let converter = KanaKanjiConverter()
+        let converter = await KanaKanjiConverter()
 
         let input1 = makeDirectInput(direct: "123")
         let input2 = makeDirectInput(direct: "1234")


### PR DESCRIPTION
Fixes #170

Add functionality to convert 3-digit and 4-digit numbers into time expressions in the format 'HH:MM'.

* Add `convertToTimeExpression` function in `Sources/KanaKanjiConverterModule/Converter/TimeExpression.swift` to handle the conversion.
* Modify `Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift` to include the new function and call it within `getWiseCandidate`.
* Add tests in `Tests/KanaKanjiConverterModuleTests/ConverterTests/TimeExpressionTests.swift` to ensure the new function works correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/azooKey/AzooKeyKanaKanjiConverter/pull/171?shareId=fcdc7916-ae62-4d81-a066-0085f5ef5e97).