### PR TITLE
feat: introduce package traits of Swift 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,12 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 import Foundation
 
-var swiftSettings: [SwiftSetting] = [
+let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
+    .interoperabilityMode(.Cxx, .when(traits: ["Zenzai"]))
 ]
 
 var dependencies: [Package.Dependency] = [
@@ -17,17 +18,14 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/ensan-hcl/swift-tokenizers", branch: "feat/minimum")
 ]
 
-var efficientNGramDependencies: [Target.Dependency] = [.product(name: "Transformers", package: "swift-tokenizers")]
+var efficientNGramDependencies: [Target.Dependency] = [
+    .product(name: "Transformers", package: "swift-tokenizers")
+]
+
 #if (!os(Linux) || !canImport(Android)) && !os(Windows)
-// Android環境・Windows環境ではSwiftyMarisaが利用できないため、除外する。
-// したがって、EfficientNGramの動作はサポートしない。
-if let envValue = ProcessInfo.processInfo.environment["LLAMA_MOCK"], envValue == "1" {
-    // LLAMA_MOCK=1の場合もサポートしない
-} else {
-    dependencies.append(.package(url: "https://github.com/ensan-hcl/SwiftyMarisa", branch: "6e145aef5583aac96dd7ff8f9fbb9944d893128e"))
-    efficientNGramDependencies.append("SwiftyMarisa")
-    swiftSettings.append(.interoperabilityMode(.Cxx))
-}
+// Android環境・Windows環境ではSwiftyMarisaが利用できないため、EfficientNGramは除外する。
+dependencies.append(.package(url: "https://github.com/ensan-hcl/SwiftyMarisa", branch: "6e145aef5583aac96dd7ff8f9fbb9944d893128e"))
+efficientNGramDependencies.append(.product(name: "SwiftyMarisa", package: "SwiftyMarisa", condition: .when(traits: ["Zenzai"])))
 #endif
 
 
@@ -139,58 +137,29 @@ if checkObjcAvailability() {
 }
 #endif
 
-if let envValue = ProcessInfo.processInfo.environment["LLAMA_MOCK"], envValue == "1" {
-    targets.append(contentsOf: [
-        .target(name: "llama-mock"),
-        .target(
-            name: "KanaKanjiConverterModule",
-            dependencies: [
-                "SwiftUtils",
-                "llama-mock",
-                "EfficientNGram",
-                .product(name: "Collections", package: "swift-collections"),
-            ],
-            swiftSettings: swiftSettings
-        )
-    ])
-} else {
-    #if os(Windows) || os(Linux)
-    targets.append(contentsOf: [
-        .systemLibrary(
-            name: "llama.cpp"
-        ),
-        .target(
-            name: "KanaKanjiConverterModule",
-            dependencies: [
-                "SwiftUtils",
-                "llama.cpp",
-                "EfficientNGram",
-                .product(name: "Collections", package: "swift-collections"),
-            ],
-            swiftSettings: swiftSettings
-        )
-    ])
-    #else
-    targets.append(contentsOf: [
-        .binaryTarget(
-            name: "llama.cpp",
-            url: "https://github.com/fkunn1326/llama.cpp/releases/download/b4844/llama-b4844-xcframework.zip",
-            // this can be computed `swift package compute-checksum llama-b4844-xcframework.zip`
-            checksum: "40bd1e58e727511649e13a6de9eb577ea8be78fe4183c2e1b382b12054849f05"
-        ),
-        .target(
-            name: "KanaKanjiConverterModule",
-            dependencies: [
-                "SwiftUtils",
-                "EfficientNGram",
-                "llama.cpp",
-                .product(name: "Collections", package: "swift-collections"),
-            ],
-            swiftSettings: swiftSettings
-        )
-    ])
-    #endif
-}
+#if os(Windows) || os(Linux)
+let llamaCppTarget: Target = .systemLibrary(name: "llama.cpp")
+#else
+let llamaCppTarget: Target = .binaryTarget(
+    name: "llama.cpp",
+    url: "https://github.com/fkunn1326/llama.cpp/releases/download/b4844/llama-b4844-xcframework.zip",
+    // this can be computed `swift package compute-checksum llama-b4844-xcframework.zip`
+    checksum: "40bd1e58e727511649e13a6de9eb577ea8be78fe4183c2e1b382b12054849f05"
+)
+#endif
+targets.append(llamaCppTarget)
+targets.append(
+    .target(
+        name: "KanaKanjiConverterModule",
+        dependencies: [
+            "SwiftUtils",
+            .target(name: "EfficientNGram", condition: .when(traits: ["Zenzai"])),
+            .target(name: "llama.cpp", condition: .when(traits: ["Zenzai"])),
+            .product(name: "Collections", package: "swift-collections"),
+        ],
+        swiftSettings: swiftSettings
+    )
+)
 
 let package = Package(
     name: "AzooKeyKanakanjiConverter",
@@ -211,6 +180,10 @@ let package = Package(
             name: "KanaKanjiConverterModule",
             targets: ["KanaKanjiConverterModule"]
         ),
+    ],
+    traits: [
+        .trait(name: "Zenzai"),
+        .default(enabledTraits: [])
     ],
     dependencies: dependencies,
     targets: targets

--- a/Sources/EfficientNGram/Inference.swift
+++ b/Sources/EfficientNGram/Inference.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if canImport(SwiftyMarisa)
+#if canImport(SwiftyMarisa) && Zenzai
 import SwiftyMarisa
 
 /// Base64 でエンコードされた Key-Value をデコードする関数

--- a/Sources/EfficientNGram/Trainer.swift
+++ b/Sources/EfficientNGram/Trainer.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if canImport(SwiftyMarisa)
+#if canImport(SwiftyMarisa) && Zenzai
 import SwiftyMarisa
 
 final class SwiftTrainer {

--- a/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
@@ -1,8 +1,8 @@
-#if canImport(llama)
+#if Zenzai
+// Zenzaiが有効でない場合、llama-mock.swiftの実装が利用可能になる
 import llama
-#else
-import llama_mock
 #endif
+
 import SwiftUtils
 import HeapModule
 import Algorithms

--- a/Sources/KanaKanjiConverterModule/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/llama-mock.swift
@@ -1,3 +1,5 @@
+#if !Zenzai
+// Zenzaiが有効でない場合、このMock実装を有効化する
 private func unimplemented<T>() -> T {
     fatalError("unimplemented")
 }
@@ -60,3 +62,4 @@ package func llama_token_to_piece(_ vocab: llama_vocab, _ token: llama_token, _ 
 
 package func llama_decode(_ ctx: llama_context, _ batch: llama_batch) -> Int { unimplemented() }
 package func llama_get_logits(_ ctx: llama_context) -> UnsafeMutablePointer<Float>? { unimplemented() }
+#endif


### PR DESCRIPTION
SwiftPMのPackage TraitsがSwift 6.1以降で利用できるので、導入した。

* `Zenzai`トレートを利用するとllama.cppおよびEfficientNgram関連の依存関係が追加され、llama.cppの推論が可能になる
  * 従来`LLAMA_MOCK=1`を環境変数として渡していたが、このやり方は公式にサポートされておらず、特にXcodeとの共用につらみがあった
* ない場合はモック実装が有効化され、こちらが使われる

コマンドラインの場合`--traits Zenzai`を渡せば制御できる。Xcodeでの扱いはまだ調べていないが、おそらく似たような感じでできる。

https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md

- [ ] 各プラットフォームでのテストを通す
- [ ] README.mdを整備する