### PR TITLE
Move lattice state to session

### DIFF
--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
@@ -58,11 +58,12 @@ final class ConverterTests: XCTestCase {
     // memo: 内部実装としては別のモジュールが呼ばれるのだが、それをテストする方法があまりないかもしれない
     func testGradualConversion() async throws {
         let converter = KanaKanjiConverter()
+        let session = converter.startSession()
         var c = ComposingText()
         let text = "ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた"
         for char in text {
             c.insertAtCursorPosition(String(char), inputStyle: .direct)
-            let results = await converter.requestCandidatesAsync(c, options: requestOptions())
+            let results = await session.requestCandidatesAsync(c, options: requestOptions())
             if c.input.count == text.count {
                 XCTAssertEqual(results.mainResults.first?.text, "幼少期からテニス水泳野球少林寺拳法など様々なスポーツを経験しながら育ち小学校時代はロサンゼルス近郊に滞在しておりゴルフやテニスを習っていた")
             }
@@ -82,7 +83,7 @@ final class ConverterTests: XCTestCase {
             ]
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .roman2kana)
-                let results = await converter.requestCandidatesAsync(c, options: requestOptions())
+                let results = await session.requestCandidatesAsync(c, options: requestOptions())
                 if c.input.count == text.count {
                     XCTAssertTrue(possibles.contains(results.mainResults.first!.text))
                 }


### PR DESCRIPTION
## Summary
- manage previous input and node cache in `KanaKanjiConverterSession`
- update `convertToLattice` to take previous input and nodes
- propagate state in session's candidate requests
- switch some converter tests to use sessions

## Testing
- `swift test -l` *(fails: couldn't clone dependencies)*