### PR TITLE
Move lattice state to session

### DIFF
--- a/Sources/KanaKanjiConverterModule/LatticeNode.swift
+++ b/Sources/KanaKanjiConverterModule/LatticeNode.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// ラティスのノード。これを用いて計算する。
-public final class LatticeNode {
+public final class LatticeNode: @unchecked Sendable {
     /// このノードが保持する辞書データ
     public let data: DicdataElement
     /// このノードの前に来ているノード。`N_best`の分だけ保存する

--- a/Sources/KanaKanjiConverterModule/RegisteredNodeProtocol.swift
+++ b/Sources/KanaKanjiConverterModule/RegisteredNodeProtocol.swift
@@ -10,14 +10,14 @@ import Foundation
 
 /// `struct`の`RegisteredNode`を再帰的に所持できるようにするため、Existential Typeで抽象化する。
 /// - Note: `indirect enum`との比較はまだやっていない。
-protocol RegisteredNodeProtocol {
+protocol RegisteredNodeProtocol: Sendable {
     var data: DicdataElement {get}
     var prev: (any RegisteredNodeProtocol)? {get}
     var totalValue: PValue {get}
     var inputRange: Range<Int> {get}
 }
 
-struct RegisteredNode: RegisteredNodeProtocol {
+struct RegisteredNode: RegisteredNodeProtocol, @unchecked Sendable {
     /// このノードが保持する辞書データ
     let data: DicdataElement
     /// 1つ前のノードのデータ

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
@@ -39,14 +39,16 @@ final class ConverterTests: XCTestCase {
 
     func testFullConversion() async throws {
         do {
-            let converter = KanaKanjiConverter()
-            var c = ComposingText()
+        let converter = KanaKanjiConverter()
+        let session = converter.startSession()
+        var c = ComposingText()
             c.insertAtCursorPosition("あずーきーはしんじだいのきーぼーどあぷりです", inputStyle: .direct)
             let results = await converter.requestCandidatesAsync(c, options: requestOptions())
             XCTAssertEqual(results.mainResults.first?.text, "azooKeyは新時代のキーボードアプリです")
         }
         do {
             let converter = KanaKanjiConverter()
+            let session = converter.startSession()
             var c = ComposingText()
             c.insertAtCursorPosition("ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた", inputStyle: .direct)
             let results = await converter.requestCandidatesAsync(c, options: requestOptions())
@@ -58,11 +60,12 @@ final class ConverterTests: XCTestCase {
     // memo: 内部実装としては別のモジュールが呼ばれるのだが、それをテストする方法があまりないかもしれない
     func testGradualConversion() async throws {
         let converter = KanaKanjiConverter()
+        let session = converter.startSession()
         var c = ComposingText()
         let text = "ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた"
         for char in text {
             c.insertAtCursorPosition(String(char), inputStyle: .direct)
-            let results = await converter.requestCandidatesAsync(c, options: requestOptions())
+            let results = await session.requestCandidatesAsync(c, options: requestOptions())
             if c.input.count == text.count {
                 XCTAssertEqual(results.mainResults.first?.text, "幼少期からテニス水泳野球少林寺拳法など様々なスポーツを経験しながら育ち小学校時代はロサンゼルス近郊に滞在しておりゴルフやテニスを習っていた")
             }
@@ -73,6 +76,7 @@ final class ConverterTests: XCTestCase {
     // memo: 内部実装としては別のモジュールが呼ばれるのだが、それをテストする方法があまりないかもしれない
     func testRoman2KanaGradualConversion() async throws {
             let converter = KanaKanjiConverter()
+            let session = converter.startSession()
             var c = ComposingText()
             let text = "youshoukikaratenisusuieiyakyuushourinjikenpounadosamazamanasupoーtuwokeikennsinagarasodatishougakkouzidaiharosanzerusukinkounitaizaisiteorigoruhuyatenisuwonaratteita"
             // 許容される変換結果
@@ -82,7 +86,7 @@ final class ConverterTests: XCTestCase {
             ]
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .roman2kana)
-                let results = await converter.requestCandidatesAsync(c, options: requestOptions())
+                let results = await session.requestCandidatesAsync(c, options: requestOptions())
                 if c.input.count == text.count {
                     XCTAssertTrue(possibles.contains(results.mainResults.first!.text))
                 }


### PR DESCRIPTION
## Summary
- manage previous input and node cache in `KanaKanjiConverterSession`
- update `convertToLattice` to take previous input and nodes
- propagate state in session's candidate requests
- switch some converter tests to use sessions
- mark lattice node types as `Sendable` and fix missing session creation

## Testing
- `swift test -l`