### PR TITLE
Add session tests and docs

### DIFF
--- a/Docs/converter_api.md
+++ b/Docs/converter_api.md
@@ -36,3 +36,21 @@ prefixとして確定された候補を与えてください。
 
 確定された候補を与えると、学習を更新します。
 
+## `startSession` と `requestCandidatesAsync`
+
+継続的な変換を行う場合は `startSession()` で `KanaKanjiConverterSession` を生成します。セッションでは非同期API `requestCandidatesAsync` を用いて候補取得を行います。
+
+```Swift
+let converter = KanaKanjiConverter()
+let session = converter.startSession()
+let options = ConvertRequestOptions(...)
+let input = ComposingText(
+    convertTargetCursorPosition: 3,
+    input: ["U", "+", "3042"].map { .init(character: Character($0), inputStyle: .direct) },
+    convertTarget: "U+3042"
+)
+let result = await session.requestCandidatesAsync(input, options: options)
+```
+
+セッションはスレッドセーフに設計されており、複数セッションを同時に利用しても互いの状態を汚染しません。
+

--- a/Tests/KanaKanjiConverterModuleTests/KanaKanjiConverterSessionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/KanaKanjiConverterSessionTests.swift
@@ -40,7 +40,57 @@ final class KanaKanjiConverterSessionTests: XCTestCase {
         let directResult = await converter.requestCandidatesAsync(input, options: options)
         let sessionResult = await session.requestCandidatesAsync(input, options: options)
 
+        XCTAssertEqual(directResult.mainResults.first?.text, sessionResult.mainResults.first?.text)
+        XCTAssertEqual(directResult.firstClauseResults.first?.text, sessionResult.firstClauseResults.first?.text)
+    }
+
+    /// Verify that session can request candidates asynchronously and match converter result.
+    func testSessionRequestCandidates() async throws {
+        let converter = KanaKanjiConverter()
+        let session = converter.startSession()
+        let options = requestOptions()
+        let input = makeDirectInput(direct: "U+3042")
+
+        let directResult = await converter.requestCandidatesAsync(input, options: options)
+        let sessionResult = await session.requestCandidatesAsync(input, options: options)
+
         XCTAssertEqual(directResult.mainResults.map(\.text), sessionResult.mainResults.map(\.text))
         XCTAssertEqual(directResult.firstClauseResults.map(\.text), sessionResult.firstClauseResults.map(\.text))
+    }
+
+    /// Ensure multiple sessions operate independently without interfering states.
+    func testMultipleSessionsIndependently() async throws {
+        let converter = KanaKanjiConverter()
+        let session1 = converter.startSession()
+        let session2 = converter.startSession()
+        let options = requestOptions()
+
+        var input1 = makeDirectInput(direct: "U+3042")
+        var input2 = makeDirectInput(direct: "U+30A2")
+
+        async let r1 = session1.requestCandidatesAsync(input1, options: options)
+        async let r2 = session2.requestCandidatesAsync(input2, options: options)
+
+        let direct1 = await converter.requestCandidatesAsync(input1, options: options)
+        let direct2 = await converter.requestCandidatesAsync(input2, options: options)
+        let result1 = await r1
+        let result2 = await r2
+
+        XCTAssertEqual(result1.mainResults.first?.text, direct1.mainResults.first?.text)
+        XCTAssertEqual(result2.mainResults.first?.text, direct2.mainResults.first?.text)
+
+        input1 = makeDirectInput(direct: "U+3044")
+        input2 = makeDirectInput(direct: "U+30A4")
+
+        async let r3 = session1.requestCandidatesAsync(input1, options: options)
+        async let r4 = session2.requestCandidatesAsync(input2, options: options)
+
+        let direct3 = await converter.requestCandidatesAsync(input1, options: options)
+        let direct4 = await converter.requestCandidatesAsync(input2, options: options)
+        let result3 = await r3
+        let result4 = await r4
+
+        XCTAssertEqual(result3.mainResults.first?.text, direct3.mainResults.first?.text)
+        XCTAssertEqual(result4.mainResults.first?.text, direct4.mainResults.first?.text)
     }
 }


### PR DESCRIPTION
## Summary
- add new asynchronous session tests
- ensure sessions don't interfere with each other
- document `startSession` and `requestCandidatesAsync` usage

## Testing
- `swift test --filter KanaKanjiConverterSessionTests/testSessionRequestCandidates`
- `swift test --filter KanaKanjiConverterSessionTests/testMultipleSessionsIndependently`
- `swift test`