### PR TITLE
Mark synchronous APIs nonisolated

### DIFF
--- a/Tests/KanaKanjiConverterModuleTests/KanaKanjiConverterSessionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/KanaKanjiConverterSessionTests.swift
@@ -93,4 +93,31 @@ final class KanaKanjiConverterSessionTests: XCTestCase {
         XCTAssertEqual(result3.mainResults.first?.text, direct3.mainResults.first?.text)
         XCTAssertEqual(result4.mainResults.first?.text, direct4.mainResults.first?.text)
     }
+
+    /// Verify that synchronous requestCandidates works and matches async version.
+    func testRequestCandidatesSync() async throws {
+        let converter = KanaKanjiConverter()
+        let session = converter.startSession()
+        let options = requestOptions()
+        let input = makeDirectInput(direct: "U+3042")
+
+        let asyncResult = await session.requestCandidatesAsync(input, options: options)
+        let syncResult = session.requestCandidates(input, options: options)
+
+        XCTAssertEqual(asyncResult.mainResults.map(\.text), syncResult.mainResults.map(\.text))
+        XCTAssertEqual(asyncResult.firstClauseResults.map(\.text), syncResult.firstClauseResults.map(\.text))
+    }
+
+    /// Ensure predictNextCharacter synchronous API returns same result as async API.
+    func testPredictNextCharacterSync() async throws {
+        let converter = KanaKanjiConverter()
+        let session = converter.startSession()
+        let options = requestOptions()
+
+        let asyncResult = await session.predictNextCharacterAsync(leftSideContext: "", count: 3, options: options)
+        let syncResult = session.predictNextCharacter(leftSideContext: "", count: 3, options: options)
+
+        XCTAssertEqual(asyncResult.map(\.character), syncResult.map(\.character))
+        XCTAssertEqual(asyncResult.map(\.value), syncResult.map(\.value))
+    }
 }


### PR DESCRIPTION
## Summary
- mark `predictNextCharacter` and `requestCandidates` as `nonisolated`
- use detached tasks to call async functions from outside the actor
- guard `predictNextCharacterAsync` when Zenzai model is disabled
- test that the synchronous APIs match their async counterparts

## Testing
- `swift test`