### PR TITLE
fix: getWiseData関連の実装を修正し、bya→ビャなどの変換を適切に表示

### DIFF
--- a/Sources/CliTool/Subcommands/SessionCommand.swift
+++ b/Sources/CliTool/Subcommands/SessionCommand.swift
@@ -13,6 +13,8 @@ extension Subcommands {
         var displayTopN: Int = 1
         @Option(name: [.customLong("zenz")], help: "gguf format model weight for zenz.")
         var zenzWeightPath: String = ""
+        @Flag(name: [.customLong("mix_english_candidate")], help: "Enable mixing English Candidates.")
+        var mixEnglishCandidate = false
         @Flag(name: [.customLong("disable_prediction")], help: "Disable producing prediction candidates.")
         var disablePrediction = false
         @Flag(name: [.customLong("enable_memory")], help: "Enable memory.")
@@ -290,7 +292,7 @@ extension Subcommands {
                 keyboardLanguage: .ja_JP,
                 typographyLetterCandidate: false,
                 unicodeCandidate: true,
-                englishCandidateInRoman2KanaInput: true,
+                englishCandidateInRoman2KanaInput: self.mixEnglishCandidate,
                 fullWidthRomanCandidate: false,
                 halfWidthKanaCandidate: false,
                 learningType: learningType,

--- a/Sources/KanaKanjiConverterModule/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/ComposingText.swift
@@ -501,7 +501,7 @@ extension ComposingText {
     /// - Returns: 領域がvalidであれば`convertTarget`を返し、invalidなら`nil`を返す。
     /// - Note: `elements = [r(k, a, n, s, h, a)]`のとき、`k,a,n,s,h,a`や`k, a`は正当だが`a, n`や`s, h`は正当ではない。`k, a, n`は特に正当であるとみなす。
     static func getConvertTargetIfRightSideIsValid(lastElement: InputElement, of originalElements: [InputElement], to rightIndex: Int, convertTargetElements: [ConvertTargetElement]) -> [Character]? {
-        debug("getConvertTargetIfRightSideIsValid", lastElement, rightIndex)
+        debug(#function, lastElement, rightIndex)
         if originalElements.endIndex < rightIndex {
             return nil
         }

--- a/Sources/KanaKanjiConverterModule/DicdataStore/TypoCorrection.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/TypoCorrection.swift
@@ -23,7 +23,7 @@ extension ComposingText {
     /// `left <= rightIndexRange.startIndex`が常に成り立つ
     func getRangesWithTypos(_ left: Int, rightIndexRange: Range<Int>) -> [[Character]: (endIndex: Int, penalty: PValue)] {
         let count = rightIndexRange.endIndex - left
-        debug("getRangesWithTypos", left, rightIndexRange, count)
+        debug(#function, left, rightIndexRange, count)
         let nodes = (0..<count).map {(i: Int) in
             Self.lengths.flatMap {(k: Int) -> [TypoCandidate] in
                 let j = i + k
@@ -100,15 +100,16 @@ extension ComposingText {
     /// closedRangeでもらう
     /// 例えば`left=4, rightIndexRange=6..<10`の場合、`4...6, 4...7, 4...8, 4...9`の範囲で計算する
     /// `left <= rightIndexRange.startIndex`が常に成り立つ
-    func getRanges(_ left: Int, rightIndexRange: Range<Int>) -> [[Character]: Int] {
+    func getRangesWithoutTypos(_ left: Int, rightIndexRange: Range<Int>) -> [[Character]: Int] {
         let count = rightIndexRange.endIndex - left
-        debug("getRangesWithTypos", left, rightIndexRange, count)
+        debug(#function, left, rightIndexRange, count)
         let nodes = (0..<count).map {(i: Int) in
             Self.lengths.flatMap {(k: Int) -> [TypoCandidate] in
                 let j = i + k
                 if count <= j {
                     return []
                 }
+                // frozen: trueとしているため、typo候補は含まれない
                 return Self.getTypo(self.input[left + i ... left + j], frozen: true)
             }
         }

--- a/Sources/KanaKanjiConverterModule/Roman2Kana.swift
+++ b/Sources/KanaKanjiConverterModule/Roman2Kana.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 enum Roman2Kana {
-    static let katakanaChanges: [String: String] = Dictionary(uniqueKeysWithValues: hiraganaChanges.map { (String($0.key), String($0.value)) })
+    static let katakanaChanges: [String: String] = Dictionary(uniqueKeysWithValues: hiraganaChanges.map { (String($0.key), String($0.value).toKatakana()) })
     static let hiraganaChanges: [[Character]: [Character]] = Dictionary(uniqueKeysWithValues: [
         "a": "あ",
         "xa": "ぁ",


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple files in the Kana-Kanji conversion module and CLI tool. The most notable changes include adding a new flag to control English candidate mixing, improving debug logging consistency, and refining typo correction logic. Additionally, there are adjustments to the Roman-to-Kana conversion logic to ensure accurate transformations.

### CLI Tool Changes:
* Added a new flag `mixEnglishCandidate` to enable or disable mixing English candidates during Roman-to-Kana input. This flag is wired into the `SessionCommand` logic to dynamically control candidate behavior. [[1]](diffhunk://#diff-cec6a8468aedce2b7fcdfdb9e329f983dd4fec3204525f4f01576c3642a69c5bR16-R17) [[2]](diffhunk://#diff-cec6a8468aedce2b7fcdfdb9e329f983dd4fec3204525f4f01576c3642a69c5bL293-R295)

### Debug Logging Improvements:
* Replaced hardcoded function names in `debug` calls with `#function` to improve logging consistency and maintainability across `DicdataStore`, `ComposingText`, and `TypoCorrection` files. [[1]](diffhunk://#diff-eff847cd988cd21faff93a458e36eab5ec2e197f76e553e667711d55b89058e4L504-R504) [[2]](diffhunk://#diff-d96cd48000bc986d800c0b1d108320608220d4c34e89d8d60ace510d612f2a4fL284-R284) [[3]](diffhunk://#diff-d96cd48000bc986d800c0b1d108320608220d4c34e89d8d60ace510d612f2a4fL391-R407) [[4]](diffhunk://#diff-82187aa5adf7985ce375bb3722c48322f218f1fe4aab04f3434d859b36126968L26-R26) [[5]](diffhunk://#diff-82187aa5adf7985ce375bb3722c48322f218f1fe4aab04f3434d859b36126968L103-R112)

### Typo Correction Refinements:
* Renamed the `getRanges` method to `getRangesWithoutTypos` and added logic to exclude typo candidates when `frozen` is set to `true`. This ensures more accurate range calculations during conversion.

### Roman-to-Kana Conversion Adjustments:
* Updated the `katakanaChanges` dictionary in `Roman2Kana.swift` to correctly convert Hiragana values to Katakana using the `toKatakana()` method. This resolves transformation inconsistencies.

### Candidate Generation Fixes:
* Refined logic in `DicdataStore` to handle candidate generation more accurately, including changes to how ranges and dynamic user dictionary matches are processed. [[1]](diffhunk://#diff-d96cd48000bc986d800c0b1d108320608220d4c34e89d8d60ace510d612f2a4fL427-R428) [[2]](diffhunk://#diff-d96cd48000bc986d800c0b1d108320608220d4c34e89d8d60ace510d612f2a4fL632-R630)