### PR TITLE
feat(breaking): enable upcoming features for future compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ import Foundation
 let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
     .interoperabilityMode(.Cxx, .when(traits: ["Zenzai"]))
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ import Foundation
 
 let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("MemberImportVisibility"),
     .interoperabilityMode(.Cxx, .when(traits: ["Zenzai"]))
 ]
 

--- a/Sources/CliTool/Anco.swift
+++ b/Sources/CliTool/Anco.swift
@@ -2,8 +2,8 @@ import KanaKanjiConverterModuleWithDefaultDictionary
 import ArgumentParser
 
 @main
-public struct Anco: AsyncParsableCommand {
-    public static let configuration = CommandConfiguration(
+struct Anco: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
         abstract: "Anco is A(zooKey) Kana-Ka(n)ji (co)nverter",
         subcommands: [
             Subcommands.Run.self,
@@ -17,5 +17,5 @@ public struct Anco: AsyncParsableCommand {
         defaultSubcommand: Subcommands.Run.self
     )
 
-    public init() {}
+    init() {}
 }

--- a/Sources/CliTool/Subcommands/EvaluateCommand.swift
+++ b/Sources/CliTool/Subcommands/EvaluateCommand.swift
@@ -74,9 +74,9 @@ extension Subcommands {
             if stable {
                 result.execution_time = 0
                 result.timestamp = 0
-                result.items.mutatingForeach {
+                result.items.mutatingForEach {
                     $0.entropy = Double(Int($0.entropy * 10)) / 10
-                    $0.outputs.mutatingForeach {
+                    $0.outputs.mutatingForEach {
                         $0.score = Double(Int($0.score))
                     }
                 }

--- a/Sources/CliTool/Subcommands/EvaluateCommand.swift
+++ b/Sources/CliTool/Subcommands/EvaluateCommand.swift
@@ -1,6 +1,7 @@
 import KanaKanjiConverterModuleWithDefaultDictionary
 import ArgumentParser
 import Foundation
+import SwiftUtils
 
 extension Subcommands {
     struct Evaluate: AsyncParsableCommand {

--- a/Sources/CliTool/Subcommands/ExperimentalPredict.swift
+++ b/Sources/CliTool/Subcommands/ExperimentalPredict.swift
@@ -1,3 +1,4 @@
+import Algorithms
 import KanaKanjiConverterModuleWithDefaultDictionary
 import ArgumentParser
 import Foundation

--- a/Sources/CliTool/Subcommands/RunCommand.swift
+++ b/Sources/CliTool/Subcommands/RunCommand.swift
@@ -1,6 +1,7 @@
 import KanaKanjiConverterModuleWithDefaultDictionary
 import ArgumentParser
 import Foundation
+import SwiftUtils
 
 extension Subcommands {
     struct Run: AsyncParsableCommand {

--- a/Sources/CliTool/Subcommands/SessionCommand.swift
+++ b/Sources/CliTool/Subcommands/SessionCommand.swift
@@ -1,6 +1,9 @@
-import KanaKanjiConverterModuleWithDefaultDictionary
+import Algorithms
 import ArgumentParser
 import Foundation
+import KanaKanjiConverterModuleWithDefaultDictionary
+import SwiftUtils
+import Tokenizers
 
 extension Subcommands {
     struct Session: AsyncParsableCommand {

--- a/Sources/CliTool/Subcommands/ZenzEvaluateCommand.swift
+++ b/Sources/CliTool/Subcommands/ZenzEvaluateCommand.swift
@@ -1,6 +1,7 @@
 import KanaKanjiConverterModuleWithDefaultDictionary
 import ArgumentParser
 import Foundation
+import SwiftUtils
 
 extension Subcommands {
     struct ZenzEvaluate: AsyncParsableCommand {

--- a/Sources/CliTool/Subcommands/ZenzEvaluateCommand.swift
+++ b/Sources/CliTool/Subcommands/ZenzEvaluateCommand.swift
@@ -69,8 +69,8 @@ extension Subcommands {
             if stable {
                 result.execution_time = 0
                 result.timestamp = 0
-                result.items.mutatingForeach {
-                    $0.outputs.mutatingForeach {
+                result.items.mutatingForEach {
+                    $0.outputs.mutatingForEach {
                         $0.score = Double(Int($0.score))
                     }
                 }

--- a/Sources/KanaKanjiConverterModule/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/ComposingText.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 ensan. All rights reserved.
 //
 
+import Foundation
 import SwiftUtils
 
 /// ユーザ入力、変換対象文字列、ディスプレイされる文字列、の3つを同時にハンドルするための構造体

--- a/Sources/KanaKanjiConverterModule/Converter/CalendarCandidate.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/CalendarCandidate.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUtils
 
 extension KanaKanjiConverter {
     /// 西暦に変換した結果を返す関数。

--- a/Sources/KanaKanjiConverterModule/Converter/CommaSeparatedNumber.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/CommaSeparatedNumber.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUtils
 
 extension KanaKanjiConverter {
     func commaSeparatedNumberCandidates(_ inputData: ComposingText) -> [Candidate] {
@@ -18,7 +19,7 @@ extension KanaKanjiConverter {
         let integerPart = parts[0]
         guard integerPart.count > 3 else { return [] }
 
-        var reversed = Array(integerPart.reversed())
+        let reversed = Array(integerPart.reversed())
         var formatted = ""
         for (i, ch) in reversed.enumerated() {
             if i > 0 && i % 3 == 0 {

--- a/Sources/KanaKanjiConverterModule/Converter/ConvertRequestOptions.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/ConvertRequestOptions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 ensan. All rights reserved.
 //
 
-import Foundation
+public import Foundation
 
 public struct ConvertRequestOptions: Sendable {
     /// 変換リクエストに必要な設定データ

--- a/Sources/KanaKanjiConverterModule/Converter/EmailAddress.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/EmailAddress.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUtils
 
 extension KanaKanjiConverter {
     private static let domains = [

--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
+import Algorithms
 import Foundation
 import SwiftUtils
 import EfficientNGram
@@ -18,7 +19,7 @@ import EfficientNGram
     }
 
     private var converter = Kana2Kanji()
-    nonisolated(unsafe) public static let defaultSpecialCandidateProviders: [any SpecialCandidateProvider] = [
+    public static let defaultSpecialCandidateProviders: [any SpecialCandidateProvider] = [
         CalendarSpecialCandidateProvider(),
         EmailAddressSpecialCandidateProvider(),
         UnicodeSpecialCandidateProvider(),

--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -7,7 +7,7 @@
 //
 
 import Algorithms
-import Foundation
+package import Foundation
 import SwiftUtils
 import EfficientNGram
 
@@ -19,7 +19,7 @@ import EfficientNGram
     }
 
     private var converter = Kana2Kanji()
-    public static let defaultSpecialCandidateProviders: [any SpecialCandidateProvider] = [
+    nonisolated public static let defaultSpecialCandidateProviders: [any SpecialCandidateProvider] = [
         CalendarSpecialCandidateProvider(),
         EmailAddressSpecialCandidateProvider(),
         UnicodeSpecialCandidateProvider(),
@@ -582,7 +582,7 @@ import EfficientNGram
         result.append(contentsOf: clause_candidates)
         result.append(contentsOf: word_candidates)
 
-        result.mutatingForeach { item in
+        result.mutatingForEach { item in
             item.withActions(self.getAppropriateActions(item))
             item.parseTemplate()
         }

--- a/Sources/KanaKanjiConverterModule/Converter/RomanTypographys.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/RomanTypographys.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUtils
 
 private extension UnicodeScalar {
     /// ローマ字の大文字かどうか

--- a/Sources/KanaKanjiConverterModule/Converter/Unicode.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/Unicode.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUtils
 
 extension KanaKanjiConverter {
     /// unicode文字列`"uxxxx, Uxxxx, u+xxxx, U+xxxx"`を対応する記号に変換する関数

--- a/Sources/KanaKanjiConverterModule/Converter/VersionCandidate.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/VersionCandidate.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUtils
 
 extension KanaKanjiConverter {
 

--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
@@ -125,7 +125,7 @@ public final class DicdataStore {
             self.closeKeyboard()
         case .importOSUserDict(let dicdata), .importDynamicUserDict(let dicdata):
             self.dynamicUserDict = dicdata
-            self.dynamicUserDict.mutatingForeach {
+            self.dynamicUserDict.mutatingForEach {
                 $0.metadata = .isFromUserDictionary
             }
         case let .forgetMemory(candidate):
@@ -258,12 +258,12 @@ public final class DicdataStore {
             data.append(contentsOf: LOUDS.getDataForLoudstxt3(identifier + "\(key)", indices: value.map {$0 & 2047}, cache: self.loudstxts[identifier + "\(key)"], option: self.requestOptions))
         }
         if identifier == "memory" {
-            data.mutatingForeach {
+            data.mutatingForEach {
                 $0.metadata = .isLearned
             }
         }
         if identifier == "user" {
-            data.mutatingForeach {
+            data.mutatingForEach {
                 $0.metadata = .isFromUserDictionary
             }
         }

--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
+import Algorithms
 import Foundation
 import SwiftUtils
 

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/zenzai.swift
@@ -1,3 +1,4 @@
+import Algorithms
 import Foundation
 import SwiftUtils
 import EfficientNGram

--- a/Sources/KanaKanjiConverterModule/LOUDS/extension LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/extension LOUDS.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
-import Foundation
+package import Foundation
 import SwiftUtils
 
 extension LOUDS {

--- a/Sources/KanaKanjiConverterModule/Replacer/TextReplacer.swift
+++ b/Sources/KanaKanjiConverterModule/Replacer/TextReplacer.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 ensan. All rights reserved.
 //
 
-import Foundation
+public import Foundation
 import SwiftUtils
 
 /// `TextReplacer`は前後の文脈に基づいて、現在のカーソル位置の語の置き換えを提案するためのモジュールである。

--- a/Sources/KanaKanjiConverterModule/Roman2Kana.swift
+++ b/Sources/KanaKanjiConverterModule/Roman2Kana.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import SwiftUtils
+
 enum Roman2Kana {
     static let katakanaChanges: [String: String] = Dictionary(uniqueKeysWithValues: hiraganaChanges.map { (String($0.key), String($0.value).toKatakana()) })
     static let hiraganaChanges: [[Character]: [Character]] = Dictionary(uniqueKeysWithValues: [

--- a/Sources/KanaKanjiConverterModule/TemplateData.swift
+++ b/Sources/KanaKanjiConverterModule/TemplateData.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
-import Foundation
+public import Foundation
 import SwiftUtils
 
 public struct TemplateData: Codable, Sendable {

--- a/Sources/KanaKanjiConverterModule/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/Zenz.swift
@@ -1,4 +1,4 @@
-import Foundation
+package import Foundation
 import SwiftUtils
 import EfficientNGram
 

--- a/Sources/KanaKanjiConverterModuleWithDefaultDictionary/KanaKanjiConverterModuleWithDefaultDictionary.swift
+++ b/Sources/KanaKanjiConverterModuleWithDefaultDictionary/KanaKanjiConverterModuleWithDefaultDictionary.swift
@@ -1,5 +1,5 @@
-@_exported import KanaKanjiConverterModule
-import Foundation
+@_exported public import KanaKanjiConverterModule
+public import Foundation
 
 public extension ConvertRequestOptions {
     static func withDefaultDictionary(

--- a/Sources/SwiftUtils/ArrayUtils.swift
+++ b/Sources/SwiftUtils/ArrayUtils.swift
@@ -18,7 +18,7 @@ package extension Sequence {
     }
 }
 
-package extension Collection {
+public extension Collection {
     /// Returns a `Set` containing the elements of this sequence with transformed values.
     /// - Parameters:
     ///   - transform: A closure that transforms each element of this sequence into a value that can be hashed.
@@ -60,7 +60,7 @@ package extension Collection {
     }
 }
 
-package extension MutableCollection {
+public extension MutableCollection {
     /// Calls the given closure with a pointer to the array's mutable contiguous storage.
     /// - Parameter
     ///   - transform: A closure that takes a pointer to the array's mutable contiguous storage.
@@ -71,7 +71,7 @@ package extension MutableCollection {
     }
 }
 
-package extension Collection {
+public extension Collection {
     /// Returns a SubSequence containing the elements of this sequence up to the first element that does not satisfy the given predicate.
     /// - Parameters:
     ///   - condition: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element should be included.
@@ -85,7 +85,7 @@ package extension Collection {
     }
 }
 
-package extension Collection where Self.Element: Equatable {
+public extension Collection where Self.Element: Equatable {
     /// Returns a Bool value indicating whether the collection has the given prefix.
     /// - Parameters:
     ///   - prefix: A collection to search for at the start of this collection.

--- a/Sources/SwiftUtils/ArrayUtils.swift
+++ b/Sources/SwiftUtils/ArrayUtils.swift
@@ -5,20 +5,20 @@
 //  Created by ensan on 2023/04/30.
 //
 
-import Algorithms
+package import Algorithms
 import Foundation
 
-public extension Sequence {
+package extension Sequence {
     /// Returns a sequence that contains the elements of this sequence followed by the elements of the given sequence.
     /// - Parameters:
     ///   - sequence: A sequence of elements to chain.
     /// - Returns: A sequence that contains the elements of this sequence followed by the elements of the given sequence.
-    @inlinable func chained<S: Sequence<Element>>(_ sequence: S) -> Chain2Sequence<Self, S> {
+    func chained<S: Sequence<Element>>(_ sequence: S) -> Chain2Sequence<Self, S> {
         chain(self, sequence)
     }
 }
 
-public extension Collection {
+package extension Collection {
     /// Returns a `Set` containing the elements of this sequence with transformed values.
     /// - Parameters:
     ///   - transform: A closure that transforms each element of this sequence into a value that can be hashed.
@@ -60,18 +60,18 @@ public extension Collection {
     }
 }
 
-public extension MutableCollection {
+package extension MutableCollection {
     /// Calls the given closure with a pointer to the array's mutable contiguous storage.
     /// - Parameter
     ///   - transform: A closure that takes a pointer to the array's mutable contiguous storage.
-    @inlinable mutating func mutatingForeach(transform closure: (inout Element) throws -> Void) rethrows {
+    @inlinable mutating func mutatingForEach(transform closure: (inout Element) throws -> Void) rethrows {
         for index in self.indices {
             try closure(&self[index])
         }
     }
 }
 
-public extension Collection {
+package extension Collection {
     /// Returns a SubSequence containing the elements of this sequence up to the first element that does not satisfy the given predicate.
     /// - Parameters:
     ///   - condition: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element should be included.
@@ -85,7 +85,7 @@ public extension Collection {
     }
 }
 
-public extension Collection where Self.Element: Equatable {
+package extension Collection where Self.Element: Equatable {
     /// Returns a Bool value indicating whether the collection has the given prefix.
     /// - Parameters:
     ///   - prefix: A collection to search for at the start of this collection.

--- a/Sources/SwiftUtils/CharacterUtils.swift
+++ b/Sources/SwiftUtils/CharacterUtils.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum CharacterUtils {
+package enum CharacterUtils {
     /// 小書きのかなカナ集合
     private static let kogakiKana: Set<Character> = [
         "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゕ", "ゖ", "っ", "ゃ", "ゅ", "ょ", "ゎ",
@@ -26,12 +26,12 @@ public enum CharacterUtils {
     }
 
     /// ローマ字(a-z, A-Zか否か)
-    @inlinable public static func isRomanLetter(_ character: Character) -> Bool {
+    @inlinable package static func isRomanLetter(_ character: Character) -> Bool {
         character.isASCII && character.isCased
     }
 
     /// 自分が小書きであれば該当する文字を返す。
-    public static func kogaki(_ character: Character) -> Character {
+    package static func kogaki(_ character: Character) -> Character {
         switch character {
         case "あ": return "ぁ"
         case "い": return "ぃ"
@@ -62,7 +62,7 @@ public enum CharacterUtils {
     }
 
     /// 小書きから大書きを返す
-    public static func ogaki(_ character: Character) -> Character {
+    package static func ogaki(_ character: Character) -> Character {
         switch character {
         case "ぁ": return "あ"
         case "ぃ": return "い"
@@ -93,11 +93,11 @@ public enum CharacterUtils {
     }
 
     /// 濁点付きか否か
-    public static func isDakuten(_ character: Character) -> Bool {
+    package static func isDakuten(_ character: Character) -> Bool {
         dakutenKana.contains(character)
     }
     /// 濁点をつけて返す
-    public static func dakuten(_ character: Character) -> Character {
+    package static func dakuten(_ character: Character) -> Character {
         switch character {
         case"う": return "ゔ"
         case"か": return "が"
@@ -145,7 +145,7 @@ public enum CharacterUtils {
         }
     }
     /// 濁点を外して返す
-    public static func mudakuten(_ character: Character) -> Character {
+    package static func mudakuten(_ character: Character) -> Character {
         switch character {
         case"ゔ": return "う"
         case"が": return "か"
@@ -193,14 +193,14 @@ public enum CharacterUtils {
         }
     }
     /// 半濁点かどうか
-    public static func isHandakuten(_ character: Character) -> Bool {
+    package static func isHandakuten(_ character: Character) -> Bool {
         [
             "ぱ", "ぴ", "ぷ", "ぺ", "ぽ",
             "パ", "ピ", "プ", "ペ", "ポ"
         ].contains(character)
     }
     /// 半濁点をつけて返す
-    public static func handakuten(_ character: Character) -> Character {
+    package static func handakuten(_ character: Character) -> Character {
         switch character {
         case"は": return "ぱ"
         case"ひ": return "ぴ"
@@ -216,7 +216,7 @@ public enum CharacterUtils {
         }
     }
     /// 半濁点を外して返す
-    public static func muhandakuten(_ character: Character) -> Character {
+    package static func muhandakuten(_ character: Character) -> Character {
         switch character {
         case"ぱ": return "は"
         case"ぴ": return "ひ"
@@ -233,7 +233,7 @@ public enum CharacterUtils {
     }
 
     /// 濁点、小書き、半濁点などを相互に変換する関数。
-    public static func requestChange(_ character: Character) -> String {
+    package static func requestChange(_ character: Character) -> String {
         if character.isLowercase {
             return character.uppercased()
         }
@@ -285,7 +285,7 @@ public enum CharacterUtils {
     }
 }
 
-public extension Character {
+package extension Character {
     /// Returns the Katakanized version of the character.
     @inlinable func toKatakana() -> Character {
         if self.unicodeScalars.count != 1 {

--- a/Sources/SwiftUtils/CharacterUtils.swift
+++ b/Sources/SwiftUtils/CharacterUtils.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-package enum CharacterUtils {
+public enum CharacterUtils {
     /// 小書きのかなカナ集合
     private static let kogakiKana: Set<Character> = [
         "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゕ", "ゖ", "っ", "ゃ", "ゅ", "ょ", "ゎ",
@@ -26,12 +26,12 @@ package enum CharacterUtils {
     }
 
     /// ローマ字(a-z, A-Zか否か)
-    @inlinable package static func isRomanLetter(_ character: Character) -> Bool {
+    @inlinable public static func isRomanLetter(_ character: Character) -> Bool {
         character.isASCII && character.isCased
     }
 
     /// 自分が小書きであれば該当する文字を返す。
-    package static func kogaki(_ character: Character) -> Character {
+    public static func kogaki(_ character: Character) -> Character {
         switch character {
         case "あ": return "ぁ"
         case "い": return "ぃ"
@@ -62,7 +62,7 @@ package enum CharacterUtils {
     }
 
     /// 小書きから大書きを返す
-    package static func ogaki(_ character: Character) -> Character {
+    public static func ogaki(_ character: Character) -> Character {
         switch character {
         case "ぁ": return "あ"
         case "ぃ": return "い"
@@ -93,11 +93,11 @@ package enum CharacterUtils {
     }
 
     /// 濁点付きか否か
-    package static func isDakuten(_ character: Character) -> Bool {
+    public static func isDakuten(_ character: Character) -> Bool {
         dakutenKana.contains(character)
     }
     /// 濁点をつけて返す
-    package static func dakuten(_ character: Character) -> Character {
+    public static func dakuten(_ character: Character) -> Character {
         switch character {
         case"う": return "ゔ"
         case"か": return "が"
@@ -145,7 +145,7 @@ package enum CharacterUtils {
         }
     }
     /// 濁点を外して返す
-    package static func mudakuten(_ character: Character) -> Character {
+    public static func mudakuten(_ character: Character) -> Character {
         switch character {
         case"ゔ": return "う"
         case"が": return "か"
@@ -193,14 +193,14 @@ package enum CharacterUtils {
         }
     }
     /// 半濁点かどうか
-    package static func isHandakuten(_ character: Character) -> Bool {
+    public static func isHandakuten(_ character: Character) -> Bool {
         [
             "ぱ", "ぴ", "ぷ", "ぺ", "ぽ",
             "パ", "ピ", "プ", "ペ", "ポ"
         ].contains(character)
     }
     /// 半濁点をつけて返す
-    package static func handakuten(_ character: Character) -> Character {
+    public static func handakuten(_ character: Character) -> Character {
         switch character {
         case"は": return "ぱ"
         case"ひ": return "ぴ"
@@ -216,7 +216,7 @@ package enum CharacterUtils {
         }
     }
     /// 半濁点を外して返す
-    package static func muhandakuten(_ character: Character) -> Character {
+    public static func muhandakuten(_ character: Character) -> Character {
         switch character {
         case"ぱ": return "は"
         case"ぴ": return "ひ"
@@ -233,7 +233,7 @@ package enum CharacterUtils {
     }
 
     /// 濁点、小書き、半濁点などを相互に変換する関数。
-    package static func requestChange(_ character: Character) -> String {
+    public static func requestChange(_ character: Character) -> String {
         if character.isLowercase {
             return character.uppercased()
         }
@@ -285,7 +285,7 @@ package enum CharacterUtils {
     }
 }
 
-package extension Character {
+public extension Character {
     /// Returns the Katakanized version of the character.
     @inlinable func toKatakana() -> Character {
         if self.unicodeScalars.count != 1 {

--- a/Sources/SwiftUtils/DataUtils.swift
+++ b/Sources/SwiftUtils/DataUtils.swift
@@ -6,14 +6,14 @@
 //  Copyright © 2022 ensan. All rights reserved.
 //
 
-import Foundation
+package import Foundation
 
-extension Data {
+package extension Data {
     /// Converts this data to an array of the given type.
     /// - Parameter:
     ///   - type: The type to convert this data to.
     /// - Returns: An array of the given type.
-    @inlinable public func toArray<T>(of type: T.Type) -> [T] {
+    func toArray<T>(of type: T.Type) -> [T] {
         self.withUnsafeBytes {pointer -> [T] in
             Array(
                 UnsafeBufferPointer(

--- a/Sources/SwiftUtils/StringUtils.swift
+++ b/Sources/SwiftUtils/StringUtils.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 
-public extension StringProtocol {
+package extension StringProtocol {
     /// ローマ字と数字のみかどうか
     ///  - note: 空文字列の場合`false`を返す。
-    @inlinable
+    @usableFromInline
     var onlyRomanAlphabetOrNumber: Bool {
         !isEmpty && range(of: "[^a-zA-Z0-9]", options: .regularExpression) == nil
     }
     /// ローマ字のみかどうか
     ///  - note: 空文字列の場合`false`を返す。
-    @inlinable
+    @usableFromInline
     var onlyRomanAlphabet: Bool {
         !isEmpty && range(of: "[^a-zA-Z]", options: .regularExpression) == nil
     }
@@ -35,20 +35,21 @@ public extension StringProtocol {
     }
     /// 英語として許容可能な文字のみで構成されているか。
     ///  - note: 空文字列の場合`false`を返す。
-    @inlinable
+    @usableFromInline
     var isEnglishSentence: Bool {
         !isEmpty && range(of: "[^0-9a-zA-Z\n !'_<>\\[\\]{}*@`\\^|~=\"#$%&\\+\\(\\),\\-\\./:;?’\\\\]", options: .regularExpression) == nil
     }
 
     /// 仮名か
-    @inlinable
+    @usableFromInline
     var isKana: Bool {
         !isEmpty && range(of: "[^ぁ-ゖァ-ヶ]", options: .regularExpression) == nil
     }
 
     /// Returns a String value in which Hiraganas are all converted to Katakana.
     /// - Returns: A String value in which Hiraganas are all converted to Katakana.
-    @inlinable func toKatakana() -> String {
+    @usableFromInline
+    func toKatakana() -> String {
         // カタカナはutf16で常に2バイトなので、utf16単位で処理して良い
         let result = self.utf16.map { scalar -> UInt16 in
             if 0x3041 <= scalar && scalar <= 0x3096 {
@@ -62,7 +63,8 @@ public extension StringProtocol {
 
     /// Returns a String value in which Katakana are all converted to Hiragana.
     /// - Returns: A String value in which Katakana are all converted to Hiragana.
-    @inlinable func toHiragana() -> String {
+    @usableFromInline
+    func toHiragana() -> String {
         // ひらがなはutf16で常に2バイトなので、utf16単位で処理して良い
         let result = self.utf16.map { scalar -> UInt16 in
             if 0x30A1 <= scalar && scalar <= 0x30F6 {

--- a/Sources/SwiftUtils/StringUtils.swift
+++ b/Sources/SwiftUtils/StringUtils.swift
@@ -41,8 +41,8 @@ extension StringProtocol {
     }
 
     /// 仮名か
-    @usableFromInline
-    package var isKana: Bool {
+    @inlinable
+    public var isKana: Bool {
         !isEmpty && range(of: "[^ぁ-ゖァ-ヶ]", options: .regularExpression) == nil
     }
 

--- a/Sources/SwiftUtils/StringUtils.swift
+++ b/Sources/SwiftUtils/StringUtils.swift
@@ -6,26 +6,26 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
-import Foundation
+public import Foundation
 
-package extension StringProtocol {
+extension StringProtocol {
     /// ローマ字と数字のみかどうか
     ///  - note: 空文字列の場合`false`を返す。
-    @usableFromInline
-    var onlyRomanAlphabetOrNumber: Bool {
+    @inlinable
+    package var onlyRomanAlphabetOrNumber: Bool {
         !isEmpty && range(of: "[^a-zA-Z0-9]", options: .regularExpression) == nil
     }
     /// ローマ字のみかどうか
     ///  - note: 空文字列の場合`false`を返す。
-    @usableFromInline
-    var onlyRomanAlphabet: Bool {
+    @inlinable
+    package var onlyRomanAlphabet: Bool {
         !isEmpty && range(of: "[^a-zA-Z]", options: .regularExpression) == nil
     }
     /// ローマ字を含むかどうか
     ///  - note: 空文字列の場合`false`を返す。
     /// 以前は正規表現ベースで実装していたが、パフォーマンス上良くなかったので以下のような実装にしたところ40倍程度高速化した。
     @inlinable
-    var containsRomanAlphabet: Bool {
+    package var containsRomanAlphabet: Bool {
         for value in self.utf8 {
             if (UInt8(ascii: "a") <= value && value <= UInt8(ascii: "z")) || (UInt8(ascii: "A") <= value && value <= UInt8(ascii: "Z")) {
                 return true
@@ -35,21 +35,21 @@ package extension StringProtocol {
     }
     /// 英語として許容可能な文字のみで構成されているか。
     ///  - note: 空文字列の場合`false`を返す。
-    @usableFromInline
-    var isEnglishSentence: Bool {
+    @inlinable
+    public var isEnglishSentence: Bool {
         !isEmpty && range(of: "[^0-9a-zA-Z\n !'_<>\\[\\]{}*@`\\^|~=\"#$%&\\+\\(\\),\\-\\./:;?’\\\\]", options: .regularExpression) == nil
     }
 
     /// 仮名か
     @usableFromInline
-    var isKana: Bool {
+    package var isKana: Bool {
         !isEmpty && range(of: "[^ぁ-ゖァ-ヶ]", options: .regularExpression) == nil
     }
 
     /// Returns a String value in which Hiraganas are all converted to Katakana.
     /// - Returns: A String value in which Hiraganas are all converted to Katakana.
-    @usableFromInline
-    func toKatakana() -> String {
+    @inlinable
+    public func toKatakana() -> String {
         // カタカナはutf16で常に2バイトなので、utf16単位で処理して良い
         let result = self.utf16.map { scalar -> UInt16 in
             if 0x3041 <= scalar && scalar <= 0x3096 {
@@ -63,8 +63,8 @@ package extension StringProtocol {
 
     /// Returns a String value in which Katakana are all converted to Hiragana.
     /// - Returns: A String value in which Katakana are all converted to Hiragana.
-    @usableFromInline
-    func toHiragana() -> String {
+    @inlinable
+    public func toHiragana() -> String {
         // ひらがなはutf16で常に2バイトなので、utf16単位で処理して良い
         let result = self.utf16.map { scalar -> UInt16 in
             if 0x30A1 <= scalar && scalar <= 0x30F6 {
@@ -87,7 +87,7 @@ package extension StringProtocol {
      " -> \d
      */
     // please use these letters in order to avoid user-inputting text crash
-    func templateDataSpecificEscaped() -> String {
+    package func templateDataSpecificEscaped() -> String {
         var result = self.replacingOccurrences(of: "\\", with: "\\b")
         result = result.replacingOccurrences(of: "\0", with: "\\0")
         result = result.replacingOccurrences(of: "\n", with: "\\n")
@@ -98,7 +98,7 @@ package extension StringProtocol {
         return result
     }
 
-    func templateDataSpecificUnescaped() -> String {
+    package func templateDataSpecificUnescaped() -> String {
         var result = self.replacingOccurrences(of: "\\d", with: "\"")
         result = result.replacingOccurrences(of: "\\s", with: " ")
         result = result.replacingOccurrences(of: "\\c", with: ",")


### PR DESCRIPTION
* MemberImportVisibilityに関する機能フラッグを有効化した
* InternalImportsByDefaultに関する機能フラッグを有効化した

参考
* https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
* https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md

> [!IMPORTANT]
> このPRは既存のAPIの一部を外部に非公開にし、`mutatingForeach`を`mutatingForEach`にリネームする変更を含むので、この変更をリリースする際には0.9.0系への更新が必要です。
