### PR TITLE
fix: Kana2Kanjiのインスタンスを引数なしで作成してしまうバグを修正

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -13,12 +13,14 @@ import EfficientNGram
 
 /// かな漢字変換の管理を受け持つクラス
 @MainActor public final class KanaKanjiConverter {
-    public init() {}
+    private let converter: Kana2Kanji
+    public init() {
+        self.converter = .init()
+    }
     public init(dicdataStore: DicdataStore) {
         self.converter = .init(dicdataStore: dicdataStore)
     }
 
-    private var converter = Kana2Kanji()
     nonisolated public static let defaultSpecialCandidateProviders: [any SpecialCandidateProvider] = [
         CalendarSpecialCandidateProvider(),
         EmailAddressSpecialCandidateProvider(),


### PR DESCRIPTION
KanaKanjiConverterのdicdataStore引数ありのコンストラクタを呼んだとしても、先に必ずKana2Kanjiのインスタンスが引数なしコンストラクタで呼ばれてしまうバグを修正します。

[azoo-key-skkserv](https://github.com/gitusp/azoo-key-skkserv) を改造しているときに、コンストラクタにDicdataStoreを渡しているにも関わらず、charID.childを開こうとしているパスが `azoo-key-skkserv.app/louds/charID.chid` のようにapp直下からのパス (workingDirectory) になっているエラーが一度出ていたことで気付きました。

```
Error: louds/charID.chidが存在しません。このエラーは深刻ですが、テスト時には無視できる場合があります。Description: Error Domain=NSCocoaErrorDomain Code=260 "The file “charID.chid” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/xxx/Library/Developer/Xcode/DerivedData/azoo-key-skkserv-dpmfkepsdukakbaxdxbrvepndgjh/Build/Products/Debug/azoo-key-skkserv.app/louds/charID.chid, NSURL=file:///Users/xxx/Library/Developer/Xcode/DerivedData/azoo-key-skkserv-dpmfkepsdukakbaxdxbrvepndgjh/Build/Products/Debug/azoo-key-skkserv.app/louds/charID.chid, NSUnderlyingError=0x600002bdf150 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

このあと正常なdicdataStore引数でKana2Kanjiの初期化を行うため、KanaKanjiConverter自体は使えています。