### PR TITLE
feat: 末尾の'n→ん'変換のためにendOfTextを追加し、これを追加することで'n<eot>->ん'のマッピングを表現した。

### DIFF
--- a/Sources/CliTool/Subcommands/SessionCommand.swift
+++ b/Sources/CliTool/Subcommands/SessionCommand.swift
@@ -211,6 +211,8 @@ extension Subcommands {
                     \(bold: ":p, :pred") - predict next one character
                     \(bold: ":%d") - select candidate at that index (like :3 to select 3rd candidate)
                     \(bold: ":ctx %s") - set the string as context
+                    \(bold: ":input %s") - insert special characters to input. Supported special characters:
+                    - eot: end of text (for finalizing composition)
                     \(bold: ":dump %s") - dump command history to specified file name (default: history.txt).
                     """)
                 default:
@@ -218,6 +220,14 @@ extension Subcommands {
                         let ctx = String(input.split(by: ":ctx ").last ?? "")
                         leftSideContext.append(ctx)
                         continue
+                    } else if input.hasPrefix(":input") {
+                        let specialInput = String(input.split(by: ":input ").last ?? "")
+                        switch specialInput {
+                        case "eot":
+                            composingText.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: inputStyle)])
+                        default:
+                            fatalError("Unknown special input: \(specialInput)")
+                        }
                     } else if input.hasPrefix(":dump") {
                         let fileName = if ":dump " < input {
                             String(input.dropFirst(6))

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/SuffixReplacementProcessing.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/SuffixReplacementProcessing.swift
@@ -89,7 +89,7 @@ extension Kana2Kanji {
                     }
                     // 変換した文字数
                     let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
-                    if nextIndex != .bothIndex(inputIndex: inputCount, surfaceIndex: surfaceCount) {
+                    if nextIndex.surfaceIndex != surfaceCount {
                         self.updateNextNodes(with: node, nextNodes: addedNodes[index: nextIndex], nBest: N_best)
                     }
                 }
@@ -121,7 +121,7 @@ extension Kana2Kanji {
                     node.values = node.prevs.map {$0.totalValue + wValue}
                 }
                 let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
-                if nextIndex.inputIndex == inputCount && nextIndex.surfaceIndex == surfaceCount {
+                if nextIndex.surfaceIndex == surfaceCount {
                     self.updateResultNode(with: node, resultNode: result)
                 } else {
                     self.updateNextNodes(with: node, nextNodes: terminalNodes[index: nextIndex], nBest: N_best)

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
@@ -64,7 +64,7 @@ struct LatticeDualIndexMap: Sendable {
         var sIndexPointer = 0
         for i in 0 ..< inputCount {
             if let sIndex = self.inputIndexToSurfaceIndexMap[i] {
-                for j in sIndexPointer ..< sIndex {
+                for j in min(surfaceCount, sIndexPointer) ..< sIndex {
                     indices.append(.surfaceIndex(j))
                 }
                 indices.append(.bothIndex(inputIndex: i, surfaceIndex: sIndex))
@@ -73,7 +73,7 @@ struct LatticeDualIndexMap: Sendable {
                 indices.append(.inputIndex(i))
             }
         }
-        for j in sIndexPointer ..< surfaceCount {
+        for j in min(surfaceCount, sIndexPointer) ..< surfaceCount {
             indices.append(.surfaceIndex(j))
         }
         return indices

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -208,7 +208,9 @@ import EfficientNGram
         switch language {
         case "en-US":
             var result: [Candidate] = []
-            let ruby = String(inputData.input.map {$0.character})
+            let ruby = String(inputData.input.compactMap {
+                if case let .character(c) = $0.piece { c } else { nil }
+            })
             let range = NSRange(location: 0, length: ruby.utf16.count)
             if !ruby.onlyRomanAlphabet {
                 return result
@@ -243,7 +245,9 @@ import EfficientNGram
             return result
         case "el":
             var result: [Candidate] = []
-            let ruby = String(inputData.input.map {$0.character})
+            let ruby = String(inputData.input.compactMap {
+                if case let .character(c) = $0.piece { c } else { nil }
+            })
             let range = NSRange(location: 0, length: ruby.utf16.count)
             if let completions = checker.completions(forPartialWordRange: range, in: ruby, language: language) {
                 if !completions.isEmpty {
@@ -336,7 +340,9 @@ import EfficientNGram
     ///   付加的な変換候補
     private func getTopLevelAdditionalCandidate(_ inputData: ComposingText, options: ConvertRequestOptions) -> [Candidate] {
         var candidates: [Candidate] = []
-        if options.englishCandidateInRoman2KanaInput, inputData.input.allSatisfy({$0.character.isASCII}) {
+        if options.englishCandidateInRoman2KanaInput, inputData.input.allSatisfy({
+            if case let .character(c) = $0.piece { c.isASCII } else { false }
+        }) {
             candidates.append(contentsOf: self.getForeignPredictionCandidate(inputData: inputData, language: "en-US", penalty: -10))
         }
         return candidates

--- a/Sources/KanaKanjiConverterModule/InputManagement/InputPiece.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/InputPiece.swift
@@ -1,0 +1,4 @@
+public enum InputPiece: Sendable, Equatable, Hashable {
+    case character(Character)
+    case endOfText
+}

--- a/Sources/KanaKanjiConverterModule/InputManagement/Roman2KanaMaps.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/Roman2KanaMaps.swift
@@ -1,7 +1,15 @@
 import Foundation
 
 enum Roman2KanaMaps {
-    static let defaultRomanToKanaMap: [[Character]: [Character]] = Dictionary(uniqueKeysWithValues: [
+    private static func constructPieceMap(_ base: [String: String], additionalMapping: [[InputPiece]: [Character]] = [:]) -> [[InputPiece]: [Character]] {
+        var map: [[InputPiece]: [Character]] = Dictionary(uniqueKeysWithValues: base.map { key, value in
+            (key.map { InputPiece.character($0) }, Array(value))
+        })
+        map.merge(additionalMapping, uniquingKeysWith: { (first, _) in first })
+        return map
+    }
+
+    private static let defaultRomanToKanaMap: [String: String] = [
         "a": "あ",
         "xa": "ぁ",
         "la": "ぁ",
@@ -312,9 +320,15 @@ enum Roman2KanaMaps {
         "zj": "↓",
         "zk": "↑",
         "zl": "→"
-    ].map {(Array($0.key), Array($0.value))})
+    ]
 
-    static let defaultAzikMap: [[Character]: [Character]] = Dictionary(uniqueKeysWithValues: [
+    /// Mapping including special end-of-text rules.
+    static let defaultRomanToKanaPieceMap = Self.constructPieceMap(defaultRomanToKanaMap, additionalMapping: [
+        [.endOfText]: [],
+        [.character("n"), .endOfText]: ["ん"]
+    ])
+
+    static let defaultAzikPieceMap: [[InputPiece]: [Character]] = Self.constructPieceMap([
         "a": "あ",
         "i": "い",
         "u": "う",
@@ -884,5 +898,7 @@ enum Roman2KanaMaps {
         "yr": "よる",
         "tb": "たび",
         "gt": "ごと",
-    ].map {(Array($0.key), Array($0.value))})
+    ], additionalMapping: [
+        [.endOfText]: [],
+    ])
 }

--- a/Tests/KanaKanjiConverterModuleTests/ComposingTextTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ComposingTextTests.swift
@@ -209,4 +209,48 @@ final class ComposingTextTests: XCTestCase {
             XCTAssertFalse(reversedMap.contains("さくじょし"))
         }
     }
+
+    func testNEndOfTextConversion() throws {
+        let elements: [ComposingText.InputElement] = [
+            .init(character: "n", inputStyle: .roman2kana),
+            .init(piece: .endOfText, inputStyle: .roman2kana)
+        ]
+        XCTAssertEqual(ComposingText.getConvertTarget(for: elements), "ん")
+    }
+
+    func testNEndOfTextComposition() throws {
+        var c = ComposingText()
+        c.insertAtCursorPosition("a", inputStyle: .roman2kana)
+        c.insertAtCursorPosition("n", inputStyle: .roman2kana)
+        XCTAssertEqual(c.convertTarget, "あn")
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        XCTAssertEqual(c.convertTarget, "あん")
+        c.insertAtCursorPosition("i", inputStyle: .roman2kana)
+        XCTAssertEqual(c.convertTarget, "あんい")
+        c.deleteBackwardFromCursorPosition(count: 1)
+        XCTAssertEqual(c.convertTarget, "あん")
+        c.deleteBackwardFromCursorPosition(count: 1)
+        XCTAssertEqual(c.convertTarget, "あ")
+        XCTAssertEqual(c.input, [.init(character: "a", inputStyle: .roman2kana)])
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        XCTAssertEqual(c.convertTarget, "あ")
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        XCTAssertEqual(c.convertTarget, "あ")
+    }
+
+    func testEndOfTextDeletion() throws {
+        var c = ComposingText()
+        c.insertAtCursorPosition("a", inputStyle: .roman2kana)
+        c.insertAtCursorPosition("n", inputStyle: .roman2kana)
+        XCTAssertEqual(c.convertTarget, "あn")
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+        XCTAssertEqual(c.convertTarget, "あん")
+        c.deleteBackwardFromCursorPosition(count: 1)
+        XCTAssertEqual(c.convertTarget, "あ")
+        XCTAssertEqual(c.input, [.init(character: "a", inputStyle: .roman2kana)])
+    }
 }

--- a/Tests/KanaKanjiConverterModuleTests/InputStyleManagerTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/InputStyleManagerTests.swift
@@ -6,23 +6,23 @@ final class InputStyleManagerTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("custom.tsv")
         try "a\tあ\nka\tか\n".write(to: url, atomically: true, encoding: .utf8)
         let table = InputStyleManager.shared.table(for: .custom(url))
-        XCTAssertEqual(table.toHiragana(currentText: [], added: "a"), Array("あ"))
-        XCTAssertEqual(table.toHiragana(currentText: ["k"], added: "a"), Array("か"))
+        XCTAssertEqual(table.toHiragana(currentText: [], added: .character("a")), Array("あ"))
+        XCTAssertEqual(table.toHiragana(currentText: ["k"], added: .character("a")), Array("か"))
     }
 
     func testCustomTableLoadingWithBlankLines() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("custom.tsv")
         try "a\tあ\n\n\nka\tか\n".write(to: url, atomically: true, encoding: .utf8)
         let table = InputStyleManager.shared.table(for: .custom(url))
-        XCTAssertEqual(table.toHiragana(currentText: [], added: "a"), Array("あ"))
-        XCTAssertEqual(table.toHiragana(currentText: ["k"], added: "a"), Array("か"))
+        XCTAssertEqual(table.toHiragana(currentText: [], added: .character("a")), Array("あ"))
+        XCTAssertEqual(table.toHiragana(currentText: ["k"], added: .character("a")), Array("か"))
     }
 
     func testCustomTableLoadingWithCommentLines() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("custom.tsv")
         try "a\tあ\n# here is comment\nka\tか\n".write(to: url, atomically: true, encoding: .utf8)
         let table = InputStyleManager.shared.table(for: .custom(url))
-        XCTAssertEqual(table.toHiragana(currentText: [], added: "a"), Array("あ"))
-        XCTAssertEqual(table.toHiragana(currentText: ["k"], added: "a"), Array("か"))
+        XCTAssertEqual(table.toHiragana(currentText: [], added: .character("a")), Array("あ"))
+        XCTAssertEqual(table.toHiragana(currentText: ["k"], added: .character("a")), Array("か"))
     }
 }

--- a/Tests/KanaKanjiConverterModuleTests/Roman2KanaTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/Roman2KanaTests.swift
@@ -5,23 +5,23 @@ final class Roman2KanaTests: XCTestCase {
     func testToHiragana() throws {
         let table = InputStyleManager.shared.table(for: .defaultRomanToKana)
         // xtsu -> っ
-        XCTAssertEqual(table.toHiragana(currentText: Array(""), added: "x"), Array("x"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("x"), added: "t"), Array("xt"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("xt"), added: "s"), Array("xts"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("xts"), added: "u"), Array("っ"))
+        XCTAssertEqual(table.toHiragana(currentText: Array(""), added: .character("x")), Array("x"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("x"), added: .character("t")), Array("xt"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("xt"), added: .character("s")), Array("xts"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("xts"), added: .character("u")), Array("っ"))
 
         // kanto -> かんと
-        XCTAssertEqual(table.toHiragana(currentText: Array(""), added: "k"), Array("k"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("k"), added: "a"), Array("か"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("か"), added: "n"), Array("かn"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("かn"), added: "t"), Array("かんt"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("かんt"), added: "o"), Array("かんと"))
+        XCTAssertEqual(table.toHiragana(currentText: Array(""), added: .character("k")), Array("k"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("k"), added: .character("a")), Array("か"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("か"), added: .character("n")), Array("かn"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("かn"), added: .character("t")), Array("かんt"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("かんt"), added: .character("o")), Array("かんと"))
 
         // zl -> →
-        XCTAssertEqual(table.toHiragana(currentText: Array(""), added: "z"), Array("z"))
-        XCTAssertEqual(table.toHiragana(currentText: Array("z"), added: "l"), Array("→"))
+        XCTAssertEqual(table.toHiragana(currentText: Array(""), added: .character("z")), Array("z"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("z"), added: .character("l")), Array("→"))
 
         // TT -> TT
-        XCTAssertEqual(table.toHiragana(currentText: Array("T"), added: "T"), Array("TT"))
+        XCTAssertEqual(table.toHiragana(currentText: Array("T"), added: .character("T")), Array("TT"))
     }
 }

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
@@ -241,6 +241,80 @@ final class ConverterTests: XCTestCase {
         XCTAssertTrue(c.isEmpty)
     }
 
+    func testTrailing_N_and_EndOfTextBehavior() async throws {
+        do {
+            let converter = await KanaKanjiConverter()
+            var c = ComposingText()
+            c.insertAtCursorPosition("kekkon", inputStyle: .roman2kana)
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let results = await converter.requestCandidates(c, options: requestOptions())
+            XCTAssertEqual(results.mainResults.first?.text, "結婚")
+        }
+        do {
+            let converter = await KanaKanjiConverter()
+            var c = ComposingText()
+            c.insertAtCursorPosition("kekko", inputStyle: .roman2kana)
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition("n", inputStyle: .roman2kana)
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let results = await converter.requestCandidates(c, options: requestOptions())
+            XCTAssertEqual(results.mainResults.first?.text, "結婚")
+        }
+        do {
+            let converter = await KanaKanjiConverter()
+            var c = ComposingText()
+            c.insertAtCursorPosition("kekkon", inputStyle: .roman2kana)
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let results = await converter.requestCandidates(c, options: requestOptions())
+            XCTAssertEqual(results.mainResults.first?.text, "結婚")
+        }
+        do {
+            let converter = await KanaKanjiConverter()
+            var c = ComposingText()
+            c.insertAtCursorPosition("aiueo", inputStyle: .roman2kana)
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let results = await converter.requestCandidates(c, options: requestOptions())
+            XCTAssertEqual(results.mainResults.first?.text, "あいうえお")
+        }
+        do {
+            let converter = await KanaKanjiConverter()
+            var c = ComposingText()
+            c.insertAtCursorPosition("an", inputStyle: .roman2kana)
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition("ka", inputStyle: .roman2kana)
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let results = await converter.requestCandidates(c, options: requestOptions())
+            XCTAssertEqual(results.mainResults.first?.text, "安価")
+        }
+        do {
+            let converter = await KanaKanjiConverter()
+            var c = ComposingText()
+            c.insertAtCursorPosition("shain", inputStyle: .roman2kana)
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let _ = await converter.requestCandidates(c, options: requestOptions())
+            c.insertAtCursorPosition([.init(piece: .endOfText, inputStyle: .roman2kana)])
+            let results = await converter.requestCandidates(c, options: requestOptions())
+            XCTAssertEqual(results.mainResults.first?.text, "社員")
+        }
+    }
 
     // 必ず正解すべきテストケース
     func testMustCases() async throws {


### PR DESCRIPTION
入力末尾で`n`がある場合、変換時には「ン」として処理される挙動が多くのIMEで実装されている。この実装は「単に末尾に`n`を追加する」などのアドホックな対処も可能であったが、そのような方法はカスタムローマ字テーブル（#227）を考慮すると妥当ではない。

このPRでは、従来の`InputElement(character:inputStyle)`を`InputElement(piece:inputStyle)`という新たな形式に変更し、`character`ではない特殊な入力を特殊なまま処理できるようにした。これにより、`.endOfText`のような特殊トークンを表現することが可能になった。

これに基づき、マッピングルールとして新たに`n <eot> -> ん`というルールを追加し、変換リクエスト時に`<eot>`を末尾に追加することにより末尾nの変換を適切に処理できるようにした。

なお、表層形が空文字列であるような入力は今まで想定しておらず、いくつかの実装に修正の必要が生じた。特に、`inputIndex`と`surfaceIndex`の対応関係の処理においては1つの`surfaceIndex`に異なる`inputIndex`が対応する可能性を考える必要が生じた。