### PR TITLE
fix: nyu→にゅ が処理されない不具合に対処

### DIFF
--- a/Sources/KanaKanjiConverterModule/InputManagement/Roman2KanaMaps.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/Roman2KanaMaps.swift
@@ -296,6 +296,7 @@ enum Roman2KanaMaps {
         "xx": "っx",
         "yy": "っy",
         "zz": "っz",
+        "ny": "ny",  // n<any> -> ん<any>の例外処理
         "xn": "ん",
         "zh": "←",
         "zj": "↓",

--- a/Tests/KanaKanjiConverterModuleTests/Roman2KanaTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/Roman2KanaTests.swift
@@ -29,6 +29,9 @@ final class Roman2KanaTests: XCTestCase {
         XCTAssertEqual(table.toHiragana(currentText: Array("n"), added: .character("+")), Array("ん+"))
         XCTAssertEqual(table.toHiragana(currentText: Array("n"), added: .character("N")), Array("んN"))
         XCTAssertEqual(table.toHiragana(currentText: Array("n"), added: .endOfText), Array("ん"))
+
+        // nyu
+        XCTAssertEqual(table.toHiragana(currentText: Array("ny"), added: .character("u")), Array("にゅ"))
     }
 
     func testAny1Cases() throws {


### PR DESCRIPTION
* `n<any> -> ん<any>`をルールとして追加したため、`ny`も`んy`と変換されてしまっていた
* これを防ぐため、`ny -> ny`のルールでオーバーライドし、`nyu`をこの方法で処理できるようにした