### PR TITLE
perf: Zenzai用の制約付き探索の実装を改善

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -170,7 +170,13 @@ extension Kana2Kanji {
                         let ccValue: PValue = self.dicdataStore.getCCValue(node.data.rcid, nextnode.data.lcid)
                         // nodeの持っている全てのprevnodeに対して
                         for (index, value) in node.values.enumerated() {
-                            // 制約を少なくとも満たしている必要がある
+                            let newValue: PValue = ccValue + value
+                            // 追加すべきindexを取得する
+                            let lastindex: Int = (nextnode.prevs.lastIndex(where: {$0.totalValue >= newValue}) ?? -1) + 1
+                            if lastindex == N_best {
+                                continue
+                            }
+                            // 制約チェックは重いので、必要なものに対してのみ行う
                             // common prefixが単語か制約のどちらかに一致している必要
                             // 制約 AB 単語 ABC (OK)
                             // 制約 AB 単語 A   (OK)
@@ -200,17 +206,11 @@ extension Kana2Kanji {
                                     continue
                                 }
                             }
-                            let newValue: PValue = ccValue + value
-                            // 追加すべきindexを取得する
-                            let lastindex: Int = (nextnode.prevs.lastIndex(where: {$0.totalValue >= newValue}) ?? -1) + 1
-                            if lastindex == N_best {
-                                continue
-                            }
-                            let newnode: RegisteredNode = node.getRegisteredNode(index, value: newValue)
                             // カウントがオーバーしている場合は除去する
                             if nextnode.prevs.count >= N_best {
                                 nextnode.prevs.removeLast()
                             }
+                            let newnode: RegisteredNode = node.getRegisteredNode(index, value: newValue)
                             // removeしてからinsertした方が速い (insertはO(N)なので)
                             nextnode.prevs.insert(newnode, at: lastindex)
                         }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -3,6 +3,72 @@ import Foundation
 import SwiftUtils
 
 extension Kana2Kanji {
+    // Streaming comparison between candidate bytes (prev chain + appended words)
+    // and the constraint bytes without building concatenated arrays.
+    private enum PrefixRelation {
+        case mismatch
+        case equal
+        case candidateIsPrefixOfConstraint
+        case constraintIsPrefixOfCandidate
+    }
+
+    // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
+    private func computeMatchedAndTotalLength(prev: (any RegisteredNodeProtocol)?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
+        // collect words from prev chain in forward order
+        var words: [String] = []
+        var p = prev
+        while let node = p {
+            if !node.data.word.isEmpty {
+                words.append(node.data.word)
+            }
+            p = node.prev
+        }
+        words.reverse()
+        words.append(currentWord)
+
+        // total = sum of utf8 counts (cheap per word)
+        let total = words.reduce(0) { $0 + $1.utf8.count }
+
+        // matched = compare up to first mismatch or until constraint end
+        var ci = 0
+        if !constraintBytes.isEmpty {
+            outer: for w in words {
+                if ci >= constraintBytes.count {
+                    break
+                }
+                for b in w.utf8 {
+                    if ci >= constraintBytes.count {
+                        break outer
+                    }
+                    if b != constraintBytes[ci] {
+                        break outer
+                    }
+                    ci += 1
+                }
+            }
+        }
+        // このprevのutf8カウントはtotalで、そのうちconstraintBytesと一致する部分がci
+        return (matched: ci, total: total)
+    }
+
+    // Extend match with next word starting from current matched index
+    private func extendMatched(matched: Int, nextWord: String, constraintBytes: [UInt8]) -> (matched: Int, mismatch: Bool) {
+        var ci = matched
+        if ci >= constraintBytes.count {
+            return (ci, false)
+        }
+        for b in nextWord.utf8 {
+            if ci >= constraintBytes.count {
+                return (ci, false)
+            }
+            if b != constraintBytes[ci] {
+                return (ci, true)
+            }
+            ci += 1
+        }
+        return (ci, false)
+    }
+
     /// カナを漢字に変換する関数, 前提はなくかな列が与えられた場合。
     /// - Parameters:
     ///   - inputData: 入力データ。
@@ -68,24 +134,36 @@ extension Kana2Kanji {
                 // 変換した文字数
                 let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
                 // 文字数がcountと等しい場合登録する
+                let constraintBytes = constraint.constraint
                 if nextIndex.surfaceIndex == surfaceCount {
+                    // Precompute matched/total lengths per prev for (prev + current word)
+                    let mtPerPrev: [(matched: Int, total: Int)] = node.prevs.indices.map { idx in
+                        self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
+                    }
+                    let cLen = constraintBytes.count
                     for index in node.prevs.indices {
-                        let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
                         // 学習データやユーザ辞書由来の場合は素通しする
                         if node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
-                            let utf8Text = newnode.getCandidateData().data.reduce(into: []) { $0.append(contentsOf: $1.word.utf8)} + node.data.word.utf8
-                            // 最終チェック
-                            let condition = (!constraint.hasEOS && utf8Text.hasPrefix(constraint.constraint)) || (constraint.hasEOS && utf8Text == constraint.constraint)
+                            let (matched, total) = mtPerPrev[index]
+                            // 最終チェック（EOS時の条件に合わせる）
+                            let condition = if constraint.hasEOS {
+                                matched == cLen && total == cLen
+                            } else {
+                                matched == cLen
+                            }
                             guard condition else {
                                 continue
                             }
                         }
+                        let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
                         result.prevs.append(newnode)
                     }
                 } else {
-                    let candidates: [[String.UTF8View.Element]] = node.getCandidateData().map {
-                        Array(($0.data.reduce(into: "") { $0.append(contentsOf: $1.word)} + node.data.word).utf8)
+                    // Precompute matched/total lengths per prev for (prev + current word)
+                    let mtPerPrev: [(matched: Int, total: Int)] = node.prevs.indices.map { idx in
+                        self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
                     }
+                    let cLen = constraintBytes.count
                     // nodeの繋がる次にあり得る全てのnextnodeに対して
                     for nextnode in lattice[index: nextIndex] {
                         // クラスの連続確率を計算する。
@@ -99,9 +177,26 @@ extension Kana2Kanji {
                             // 制約 AB 単語 AC  (NG)
                             // ただし、学習データやユーザ辞書由来の場合は素通しする
                             if nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
-                                let utf8Text = candidates[index] + nextnode.data.word.utf8
-                                let condition = (!constraint.hasEOS && (utf8Text.hasPrefix(constraint.constraint) || constraint.constraint.hasPrefix(utf8Text))) || (constraint.hasEOS && utf8Text.count < constraint.constraint.count && constraint.constraint.hasPrefix(utf8Text))
-                                guard condition else {
+                                let (matchedPrev, totalPrev) = mtPerPrev[index]
+                                // ensure no prior mismatch
+                                guard matchedPrev == min(totalPrev, cLen) else {
+                                    continue
+                                }
+                                let nextLen = nextnode.data.word.utf8.count
+                                // matchedPrevまではconstraintBytesと一致しているので、その先をチェックする
+                                let (matchedExt, mismatch) = self.extendMatched(matched: matchedPrev, nextWord: nextnode.data.word, constraintBytes: constraintBytes)
+                                if mismatch {
+                                    continue
+                                }
+                                let newTotal = totalPrev + nextLen
+                                let ok: Bool = if constraint.hasEOS {
+                                    // require strict prefix of constraint
+                                    matchedExt == newTotal && newTotal < cLen
+                                } else {
+                                    // accept either: constraint is prefix of candidate, or candidate is prefix of constraint
+                                    (matchedExt == cLen) || (newTotal <= cLen && matchedExt == newTotal)
+                                }
+                                guard ok else {
                                     continue
                                 }
                             }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -3,15 +3,6 @@ import Foundation
 import SwiftUtils
 
 extension Kana2Kanji {
-    // Streaming comparison between candidate bytes (prev chain + appended words)
-    // and the constraint bytes without building concatenated arrays.
-    private enum PrefixRelation {
-        case mismatch
-        case equal
-        case candidateIsPrefixOfConstraint
-        case constraintIsPrefixOfCandidate
-    }
-
     // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
     private func computeMatchedAndTotalLength(prev: (any RegisteredNodeProtocol)?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
         // collect words from prev chain in forward order


### PR DESCRIPTION
* 制約付き探索では候補が制約を満たすかを適宜チェックして枝刈りを行うが、このチェックがかなり重たいという問題があった
* そこで、チェックを高速化した