### PR TITLE
perf: RegisteredNodeにindirect enumを用いることで、testGradualConversionのケースにおいてprocessResultの処理時間を20%改善（全体では170ms程度短縮）

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -4,7 +4,7 @@ import SwiftUtils
 
 extension Kana2Kanji {
     // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
-    private func computeMatchedAndTotalLength(prev: (any RegisteredNodeProtocol)?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
+    private func computeMatchedAndTotalLength(prev: RegisteredNode?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
         // collect words from prev chain in forward order
         var words: [String] = []
         var p = prev


### PR DESCRIPTION
LatticeNodeのgetCandidateなどで顕著に改善した。

* Before
<img width="2032" height="1106" alt="image" src="https://github.com/user-attachments/assets/4529c539-e043-4803-8958-6c07f3507602" />
* After
<img width="2032" height="1106" alt="image" src="https://github.com/user-attachments/assets/6812d342-2bad-4a4b-a18a-bc5fc2ace4cf" />
