### PR TITLE
perf: draft modelingの際の辞書引きを最小化して高速化

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -76,7 +76,7 @@ extension Kana2Kanji {
     /// (3)(1)のregisterされた結果をresultノードに追加していく。この際EOSとの連接計算を行っておく。
     ///
     /// (4)ノードをアップデートした上で返却する。
-    func kana2lattice_all_with_prefix_constraint(_ inputData: ComposingText, N_best: Int, constraint: PrefixConstraint) -> (result: LatticeNode, lattice: Lattice) {
+    func kana2lattice_all_with_prefix_constraint(_ inputData: ComposingText, N_best: Int, constraint: PrefixConstraint, cachedLattice: Lattice? = nil) -> (result: LatticeNode, lattice: Lattice) {
         debug("新規に計算を行います。inputされた文字列は\(inputData.input.count)文字分の\(inputData.convertTarget)。制約は\(constraint)")
         let result: LatticeNode = LatticeNode.EOSNode
         let inputCount: Int = inputData.input.count

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
@@ -158,6 +158,28 @@ struct Lattice: Sequence {
         }
     }
 
+    func resetNodeStates() {
+        // 探索で変化した状態をすべて削除する
+        self.inputIndexedNodes.forEach { nodes in
+            nodes.forEach {
+                $0.prevs.removeAll()
+                $0.values.removeAll()
+                if $0.range.startIndex.isZero {
+                    $0.prevs.append(.BOSNode())
+                }
+            }
+        }
+        self.surfaceIndexedNodes.forEach { nodes in
+            nodes.forEach {
+                $0.prevs.removeAll()
+                $0.values.removeAll()
+                if $0.range.startIndex.isZero {
+                    $0.prevs.append(.BOSNode())
+                }
+            }
+        }
+    }
+
     subscript(index index: LatticeDualIndexMap.DualIndex) -> LatticeNodeArray {
         get {
             let iNodes: [LatticeNode] = if let iIndex = index.inputIndex { self.inputIndexedNodes[iIndex] } else { [] }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -144,7 +144,7 @@ extension Kana2Kanji {
                                 insertedCandidates.insert(mostLiklyCandidate, at: 1)
                             } else if alternativeConstraint.probabilityRatio > 0.5 {
                                 // 十分に高い確率の場合、変換器を実際に呼び出して候補を作ってもらう
-                                let draftResult = self.kana2lattice_all_with_prefix_constraint(inputData, N_best: 3, constraint: PrefixConstraint(alternativeConstraint.prefixConstraint))
+                                let draftResult = self.kana2lattice_all_with_prefix_constraint(inputData, N_best: 3, constraint: PrefixConstraint(alternativeConstraint.prefixConstraint), cachedLattice: lattice)
                                 let candidates = draftResult.result.getCandidateData().map(self.processClauseCandidate)
                                 let best: (Int, Candidate)? = candidates.enumerated().reduce(into: nil) { best, pair in
                                     if let (_, c) = best, pair.1.value > c.value {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -80,7 +80,7 @@ extension Kana2Kanji {
                 self.kana2lattice_all(inputData, N_best: 2, needTypoCorrection: false)
             } else {
                 // 制約がついている場合は高速になるので、N=3としている
-                self.kana2lattice_all_with_prefix_constraint(inputData, N_best: 3, constraint: constraint)
+                self.kana2lattice_all_with_prefix_constraint(inputData, N_best: 3, constraint: constraint, cachedLattice: lattice.isEmpty ? nil : lattice)
             }
             if lattice.isEmpty {
                 // 初回のみ


### PR DESCRIPTION
これまで、繰り返し制約付き探索を行う場合は都度辞書を引いていた。しかしこれは割と重たい。そこで辞書引きを最初の1回のみ行い、あとはそれを使いまわす構造にしたところ、Inference Limit = 1のケースで25%の速度改善を得た