### PR TITLE
perf: Zenzaiを利用した逐次入力のケースにおいて、辞書データをキャッシュして使いまわすことにより、ZenzaiTests.testGradualConversion_Roman2Kanaのケースで25%の高速化を達成。

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -55,7 +55,7 @@ extension Kana2Kanji {
         }
     }
 
-    struct PrefixConstraint: Equatable, Hashable, CustomStringConvertible {
+    struct PrefixConstraint: Sendable, Equatable, Hashable, CustomStringConvertible {
         init(_ constraint: [UInt8], hasEOS: Bool = false) {
             self.constraint = constraint
             self.hasEOS = hasEOS
@@ -175,7 +175,8 @@ extension Kana2Kanji {
                                 insertedCandidates.insert(mostLiklyCandidate, at: 1)
                             } else if alternativeConstraint.probabilityRatio > 0.5 {
                                 // 十分に高い確率の場合、変換器を実際に呼び出して候補を作ってもらう
-                                let draftResult = self.kana2lattice_all_with_prefix_constraint(inputData, N_best: 3, constraint: PrefixConstraint(alternativeConstraint.prefixConstraint))
+                                lattice.resetNodeStates()
+                                let draftResult = self.kana2lattice_all_with_prefix_constraint(inputData, N_best: 3, constraint: PrefixConstraint(alternativeConstraint.prefixConstraint), preprocessedLattice: lattice)
                                 let candidates = draftResult.result.getCandidateData().map(self.processClauseCandidate)
                                 let best: (Int, Candidate)? = candidates.enumerated().reduce(into: (Int, Candidate)?.none) { best, pair in
                                     if let (_, c) = best, pair.1.value > c.value {


### PR DESCRIPTION
* `kana2kanji_all`と`kana2kanji_all_with_prefix_constraint`に`preprocessedLattice`の概念を導入した。ここには事前処理済みの`Lattice`を指定することができ、これがある場合は通常の辞書引きをスキップする
* これにより、Zenzaiでも辞書引き結果をin-call / cross-callでキャッシュできるようになった。
* これを適用したところ、逐次入力の基本的なケースにおいて処理速度が顕著に改善し、最も一般的なローマ字入力のケースでは25%程度の改善になった。