### PR TITLE
fix: forceGetInputCursorpositionの実装方法を変更

### DIFF
--- a/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
@@ -125,7 +125,7 @@ public struct ComposingText: Sendable {
             // 今回の文字入力による変換が、前の暫定独立セグメントの文字を含むテーブルエントリによって行われた場合
             // 新セグメントは前のセグメントに依存しているので、ここで前のセグメントとの境界を消すことで、新しい独立セグメントをつくる
             while let lastIndependentSegment =  independentSegmentBoundaries.popLast() {
-                // matchDepthは、現在の文字を入力する際に使われた、ローマ字かな変換テーブルのエントリの1列目の長さ
+                // deletedCountは、現在の文字を入力した際に関連(依存)した文字列の長さ
                 if lastIndependentSegment.surfaceIndex <= convertedLength - deletedCount {
                     // これ以上前のセグメントには依存していないので一度消した境界を戻す
                     independentSegmentBoundaries.append(lastIndependentSegment)

--- a/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
@@ -484,17 +484,6 @@ extension ComposingText {
         }
     }
 
-    static func updateConvertTarget(current: [Character], inputStyle: InputStyle, newCharacter: Character) -> [Character] {
-        switch inputStyle {
-        case .direct:
-            return current + [newCharacter]
-        case .roman2kana:
-            return InputStyleManager.shared.table(for: .defaultRomanToKana).toHiragana(currentText: current, added: .character(newCharacter))
-        case .mapped(let id):
-            return InputStyleManager.shared.table(for: id).toHiragana(currentText: current, added: .character(newCharacter))
-        }
-    }
-
     static func initializeConvertTarget(cachedTable: borrowing InputTable?, newCharacter: Character) -> [Character] {
         if cachedTable != nil {
             var buf: [Character] = []

--- a/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
@@ -88,13 +88,14 @@ public struct ComposingText: Sendable {
         // 2. character = "a"
         //    roman2kana = "か"
         //    independentSegment = [ka]
-        //    target.hasPrefix(roman2kana)がtrueなので、lastPrefixIndex = 2, lastPrefix = "か"
+        //    `a`が`k`とセットになることで`か`が入力される
         // 3. character = "n"
         //    roman2kana = "かn"
         //    independentSegment = [ka, n]
         // 4. character = "s"
         //    roman2kana = "かんs"
         //    independentSegment = [ka, ns]
+        //    `ん`は`n`に続いて文字が入力されることで変換されるので、`n`と`s`は互いに独立でない
         // 5. character = "h"
         //    roman2kana = "かんsh"
         //    independentSegment = [ka, ns, h]
@@ -225,11 +226,11 @@ public struct ComposingText: Sendable {
         // input: [k, a, n, s, h, a]
         // count = 1
         // currentPrefix = かんしゃ
-        // これから行く位置
-        //  targetCursorPosition = forceGetInputCursorPosition(かんし) = 4
+        // これから行く位置: 3文字目
+        //  targetCursorPosition = forceGetInputCursorPosition(3) = 4
         //  副作用でinputは[k, a, ん, し, ゃ]
-        // 現在の位置
-        //  inputCursorPosition = forceGetInputCursorPosition(かんしゃ) = 5
+        // 現在の位置: 4文字目
+        //  inputCursorPosition = forceGetInputCursorPosition(4) = 5
         //  副作用でinputは[k, a, ん, し, ゃ]
         // inputを更新する
         //  input =   (input.prefix(targetCursorPosition) = [k, a, ん, し])
@@ -241,19 +242,16 @@ public struct ComposingText: Sendable {
         // input: [k, a, n, s, h, a]
         // count = 2
         // currentPrefix = かんしゃ
-        // これから行く位置
-        //  targetCursorPosition = forceGetInputCursorPosition(かん) = 3
+        // これから行く位置: 2文字目
+        //  targetCursorPosition = forceGetInputCursorPosition(2) = 3
         //  副作用でinputは[k, a, ん, s, h, a]
-        // 現在の位置
-        //  inputCursorPosition = forceGetInputCursorPosition(かんしゃ) = 6
+        // 現在の位置: 4文字目
+        //  inputCursorPosition = forceGetInputCursorPosition(4) = 6
         //  副作用でinputは[k, a, ん, s, h, a]
         // inputを更新する
         //  input =   (input.prefix(targetCursorPosition) = [k, a, ん])
         //          + (input.suffix(input.count - inputCursorPosition) = [])
         //        =   [k, a, ん]
-
-        // 今いる位置
-        // let currentSurfaceCursorPosition = self.convertTargetBeforeCursor
 
         // この2つの値はこの順で計算する。
         // これから行く位置

--- a/Sources/KanaKanjiConverterModule/InputManagement/InputTable.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/InputTable.swift
@@ -234,33 +234,8 @@ struct InputTable: Sendable {
     /// In‑place variant: mutates `buffer` and returns (deleted, added) counts.
     /// Semantics match `toHiragana(currentText:added:)` but avoids new allocations
     /// when possible by editing the tail of `buffer` directly.
-    borrowing func apply(to buffer: inout [Character], added: InputPiece) {
-        // Greedy match without temporary array allocation.
-        let bestMatch = Self.matchGreedy(root: self.trieRoot, buffer: buffer, added: added, maxKeyCount: self.maxKeyCount)
-
-        if let (bestNode, bestState, matchedDepth) = bestMatch, let kana = bestNode.outputValue(state: bestState) {
-            let deleteCount = max(0, matchedDepth - 1)
-            if deleteCount > 0 {
-                buffer.removeLast(deleteCount)
-            }
-            if !kana.isEmpty {
-                buffer.append(contentsOf: kana)
-            }
-            return
-        }
-
-        switch added {
-        case .character(let ch):
-            buffer.append(ch)
-        case .compositionSeparator:
-            break
-        }
-    }
-
-    /// Same as apply(to:added:) but returns deletedCount.
-    /// Semantics match `toHiragana(currentText:added:)` but avoids new allocations
-    /// when possible by editing the tail of `buffer` directly.
-    borrowing func applyWithDeletedCount(to buffer: inout [Character], added: InputPiece) -> Int {
+    @discardableResult
+    borrowing func apply(to buffer: inout [Character], added: InputPiece) -> Int {
         // Greedy match without temporary array allocation.
         let bestMatch = Self.matchGreedy(root: self.trieRoot, buffer: buffer, added: added, maxKeyCount: self.maxKeyCount)
 

--- a/Tests/KanaKanjiConverterModuleTests/ComposingTextTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ComposingTextTests.swift
@@ -145,6 +145,38 @@ final class ComposingTextTests: XCTestCase {
             XCTAssertEqual(c.convertTarget, "あかふ")
             XCTAssertEqual(c.convertTargetCursorPosition, 3)
         }
+        // カスタム (危険なケース)
+        do {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("custom_delete1.tsv")
+            try "o\tおは\nおはy\tおはよう".write(to: url, atomically: true, encoding: .utf8) // カスタムテーブルを保存
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "oy", inputStyle: .mapped(id: .custom(url))) // おはよう|
+            _ = c.moveCursorFromCursorPosition(count: -3) // お|はよう
+            // 「お」を消す
+            c.deleteForwardFromCursorPosition(count: 1)   // お|よう
+            XCTAssertEqual(c.input, [
+                ComposingText.InputElement(character: "お", inputStyle: .frozen),
+                ComposingText.InputElement(character: "よ", inputStyle: .frozen),
+                ComposingText.InputElement(character: "う", inputStyle: .frozen),
+            ])
+            XCTAssertEqual(c.convertTarget, "およう")
+            XCTAssertEqual(c.convertTargetCursorPosition, 1)
+        }
+        // カスタム (循環を含むケース)
+        do {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("custom_delete2.tsv")
+            try "a\tあ\ne\tえ\nあi\tい\nいu\tあ".write(to: url, atomically: true, encoding: .utf8) // カスタムテーブルを保存
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "eaiu", inputStyle: .mapped(id: .custom(url))) // えあ|
+            _ = c.moveCursorFromCursorPosition(count: -1) // え|あ
+            // 「あ」を消す
+            c.deleteForwardFromCursorPosition(count: 1) // え|
+            XCTAssertEqual(c.input, [
+                ComposingText.InputElement(character: "e", inputStyle: .mapped(id: .custom(url))),
+            ])
+            XCTAssertEqual(c.convertTarget, "え")
+            XCTAssertEqual(c.convertTargetCursorPosition, 1)
+        }
 
     }
 


### PR DESCRIPTION
カスタムテーブルの変更に柔軟に対応できるように実装を変更しました。

## 概要
- convertTarget全体をみるため引数をインデックスに変更
- 削除/ひらがなを追加しても他の部分に影響がないセグメント(独立セグメント)のリストを作成し、引数のインデックスがセグメントの途中にある場合はそのセグメントをすべてひらがなに置き換える
- ~~apply,updateConvertTargetElementsにdeletedCountを返すバリアントを追加~~

## forceGetInputCursorPositionの挙動の変化

次のようなテーブルを作成した場合
|left|right|
|:---|:--|
|a|あ|
|ke|け|
|ma|ま|
|shi|し|
|te|て|
|ましてo|ましておめでとう|
|あけましておめでとうg|あけまして|

### 1. `akemashiteo`入力→`あけましておめでとう`→`し`削除
- 変更前: `あけまてo` `input = [a, k, e, m, a, t, e, o]`
- 変更後: `あけまておめでとう` `input = [a, k, e, ま, て, お, め, で, と, う]`
  `ましてo → ましておめでとう`は前の`まして`に依存しているので,`ましておめでとう`が一つの独立セグメントとして扱われる
### 2. `akemashiteog`入力→`あけまして`→カーソルが右端にある状態で1文字削除
- 変更前: `あけましog` `input = [a, k, e, m, a, s, h, i, o, g]`
- 変更後: `あけまし` `input = [あ, け, ま, し]`
  入力後に元の文字列に戻る場合に、先に文字列が成立した位置を返していた問題を解消
