### PR TITLE
perf: クラス間連接コストの計算を高速化

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessing.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessing.swift
@@ -102,12 +102,13 @@ extension Kana2Kanji {
     }
     /// N-Best計算を高速に実行しつつ、遷移先ノードを更新する
     func updateNextNodes(with node: LatticeNode, nextNodes: some Sequence<LatticeNode>, nBest: Int) {
+        let ccLatter = self.dicdataStore.getCCLatter(node.data.rcid)
         for nextnode in nextNodes {
             if self.dicdataStore.shouldBeRemoved(data: nextnode.data) {
                 continue
             }
             // クラスの連続確率を計算する。
-            let ccValue: PValue = self.dicdataStore.getCCValue(node.data.rcid, nextnode.data.lcid)
+            let ccValue: PValue = ccLatter.get(nextnode.data.lcid)
             // nodeの持っている全てのprevnodeに対して
             for (index, value) in node.values.enumerated() {
                 let newValue: PValue = ccValue + value

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -160,10 +160,11 @@ extension Kana2Kanji {
                         self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
                     }
                     let cLen = constraintBytes.count
+                    let ccLatter = self.dicdataStore.getCCLatter(node.data.rcid)
                     // nodeの繋がる次にあり得る全てのnextnodeに対して
                     for nextnode in lattice[index: nextIndex] {
                         // クラスの連続確率を計算する。
-                        let ccValue: PValue = self.dicdataStore.getCCValue(node.data.rcid, nextnode.data.lcid)
+                        let ccValue: PValue = ccLatter.get(nextnode.data.lcid)
                         // nodeの持っている全てのprevnodeに対して
                         for (index, value) in node.values.enumerated() {
                             let newValue: PValue = ccValue + value

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/PredictionProcessing.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/PredictionProcessing.swift
@@ -67,8 +67,9 @@ extension Kana2Kanji {
                 DicdataStore.predictionUsable[$0.rcid] && $0.word.hasPrefix(totalWord)
             }
 
+            let ccLatter = self.dicdataStore.getCCLatter(prefixCandidateData.last?.rcid ?? CIDData.BOS.cid)
             for data in dicdata {
-                let ccValue = self.dicdataStore.getCCValue(prefixCandidateData.last?.rcid ?? CIDData.BOS.cid, data.lcid)
+                let ccValue = ccLatter.get(data.lcid)
                 let includeMMValueCalculation = DicdataStore.includeMMValueCalculation(data)
                 let mmValue = includeMMValueCalculation ? self.dicdataStore.getMMValue(prefixCandidate.lastMid, data.mid) : .zero
                 let wValue = data.value()
@@ -103,8 +104,9 @@ extension Kana2Kanji {
         for candidate in preparts {
             if let last = candidate.data.last {
                 let dicdata = self.dicdataStore.getZeroHintPredictionDicdata(lastRcid: last.rcid)
+                let ccLatter = self.dicdataStore.getCCLatter(last.rcid)
                 for data in dicdata {
-                    let ccValue = self.dicdataStore.getCCValue(last.rcid, data.lcid)
+                    let ccValue = ccLatter.get(data.lcid)
                     let includeMMValueCalculation = DicdataStore.includeMMValueCalculation(data)
                     let mmValue = includeMMValueCalculation ? self.dicdataStore.getMMValue(candidate.lastMid, data.mid) : .zero
                     let wValue = data.value()

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Prediction.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Prediction.swift
@@ -87,10 +87,11 @@ extension Kana2Kanji {
         var result: [Candidate] = []
 
         result.reserveCapacity(N_best &+ 1)
+        let ccLatter = self.dicdataStore.getCCLatter(lastRcid)
         for data in (dicdata + osuserdict) {
             let includeMMValueCalculation = DicdataStore.includeMMValueCalculation(data)
             let mmValue: PValue = includeMMValueCalculation ? self.dicdataStore.getMMValue(lastMid, data.mid) : .zero
-            let ccValue: PValue = self.dicdataStore.getCCValue(lastRcid, data.lcid)
+            let ccValue: PValue = ccLatter.get(data.lcid)
             let penalty: PValue = -PValue(data.ruby.count &- lastRuby.count) * 3.0   // 文字数差をペナルティとする
             let wValue: PValue = data.value()
             let newValue: PValue = lastCandidate.value + mmValue + ccValue + wValue + penalty - ignoreCCValue


### PR DESCRIPTION
* クラス間連接コストの計算は探索中頻繁に行われるが、ここが思ったよりも時間を食っていた。
* ccValueの取得においてメモリ上の排他制御が問題になっていたので、行単位アクセスに最適化したAPIを用いて改善した

これにより #249 で取り扱ったKanaKanjiConverterModuleWithDefaultDictionaryTests.ZenzaiTests/testGradualConversion_Roman2Kanaのケースでは10%の改善が得られた。一連の高速化の結果は以下の通り。

* #249 適用前: 10.46s
* #249 適用後: 7.69s
* #250 適用後: 6.71s
* #252 適用後: 5.99s
