### PR TITLE
perf: 複数のボトルネック箇所に対処

### DIFF
--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -254,7 +254,18 @@ public final class DicdataStore {
             }
 
             mutating func setUnreachablePath<C: Collection<Character>>(target: C) where C.Indices == Range<Int> {
-                if self.surface[self.range.leftIndex...].hasPrefix(target) {
+                // Compare manually to avoid generic hasPrefix overhead
+                let suffix = self.surface[self.range.leftIndex...]
+                var it = target.makeIterator()
+                var idx = suffix.startIndex
+                var matched = 0
+                while let t = it.next() {
+                    guard idx != suffix.endIndex else { break }
+                    if suffix[idx] != t { return }
+                    matched += 1
+                    idx = suffix.index(after: idx)
+                }
+                if matched == target.count {
                     // new upper boundを計算
                     let currentLowerBound = self.range.rightIndexRange.lowerBound
                     let currentUpperBound = self.range.rightIndexRange.upperBound

--- a/Sources/KanaKanjiConverterModule/InputManagement/InputTable.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/InputTable.swift
@@ -118,9 +118,12 @@ struct InputTable: Sendable {
             root.add(reversedKey: key.reversed().map { $0 }, output: value)
         }
         self.trieRoot = root
+        self.maxUnstableSuffixLength = self.unstableSuffixes.map { $0.count }.max() ?? 0
     }
 
     let unstableSuffixes: Set<[Character]>
+    // Fast bound to avoid scanning entire set when checking suffixes
+    let maxUnstableSuffixLength: Int
     let maxKeyCount: Int
     let possibleNexts: [String: [String]]
 

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -8,8 +8,8 @@
 
 @testable import KanaKanjiConverterModule
 @testable import KanaKanjiConverterModuleWithDefaultDictionary
-import XCTest
 import SwiftUtils
+import XCTest
 
 final class DicdataStoreTests: XCTestCase {
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: KanaKanjiConverterModule.InputStyle) {

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -9,6 +9,7 @@
 @testable import KanaKanjiConverterModule
 @testable import KanaKanjiConverterModuleWithDefaultDictionary
 import XCTest
+import SwiftUtils
 
 final class DicdataStoreTests: XCTestCase {
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: KanaKanjiConverterModule.InputStyle) {
@@ -239,7 +240,7 @@ final class DicdataStoreTests: XCTestCase {
         do {
             var c = ComposingText()
             c.insertAtCursorPosition("999999999999", inputStyle: .roman2kana)
-            let result = dicdataStore.getWiseDicdata(convertTarget: c.convertTarget, inputData: c, surfaceRange: 0..<12)
+            let result = dicdataStore.getWiseDicdata(convertTarget: c.convertTarget, surfaceRange: 0..<12, fullText: Array(c.convertTarget.toKatakana()))
             XCTAssertTrue(result.contains(where: {$0.word == "999999999999"}))
             XCTAssertTrue(result.contains(where: {$0.word == "九千九百九十九億九千九百九十九万九千九百九十九"}))
         }


### PR DESCRIPTION
やや小粒だがボトルネックとなっていた箇所を特定し、集中的に最適化した。

* `setUnreachable`の判定処理が重かったので、軽量化（ZenzaiTests.testGradualConversion_Roman2Kana: 5.99s -> 5.83s）
* `getWiseDicdata`の日本語数字パースが重かったので、軽量化（ZenzaiTests.testGradualConversion_Roman2Kana: 5.83s -> 5.35s）
* `getDicdataFromLoudstxt3`のパース処理が重かったので、軽量化（ZenzaiTests.testGradualConversion_Roman2Kana: 5.35s -> 4.77s）

これにより #249 で取り扱ったKanaKanjiConverterModuleWithDefaultDictionaryTests.ZenzaiTests/testGradualConversion_Roman2Kanaのケースでは、全体で 5.99s -> 4.77s（20%改善）となった。一連の最適化で、トータルでは55%程度の改善となった。

* #249 適用前: 10.46s
* #249 適用後: 7.69s
* #250 適用後: 6.71s
* #252 適用後: 5.99s
* #253 適用後: 4.77s