### PR TITLE
perf: 最適化をさらに進める

### DIFF
--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/extension LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/extension LOUDS.swift
@@ -67,8 +67,8 @@ extension LOUDS {
 
     package static func loadUserDictionary(userDictionaryURL: URL) -> LOUDS? {
         let (charsURL, loudsURL) = (
-            userDictionaryURL.appendingPathComponent("user.loudschars2", isDirectory: false),
-            userDictionaryURL.appendingPathComponent("user.louds", isDirectory: false)
+            userDictionaryURL.appending(path: "user.loudschars2", directoryHint: .notDirectory),
+            userDictionaryURL.appending(path: "user.louds", directoryHint: .notDirectory)
         )
         return load(charsURL: charsURL, loudsURL: loudsURL)
     }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -140,24 +140,26 @@ public final class DicdataStore {
             return self.loudses[query]
         }
         if query == "user" {
-            if let cached = state.userDictionaryLOUDS {
-                return cached
+            if state.userDictionaryHasLoaded {
+                return state.userDictionaryLOUDS
             } else if let userDictionaryURL = state.userDictionaryURL,
                       let louds = LOUDS.loadUserDictionary(userDictionaryURL: userDictionaryURL) {
-                state.userDictionaryLOUDS = louds
+                state.updateUserDictionaryLOUDS(louds)
                 return louds
             } else {
+                state.updateUserDictionaryLOUDS(nil)
                 debug("Error: ユーザ辞書のloudsファイルの読み込みに失敗しましたが、このエラーは深刻ではありません。")
             }
         }
         if query == "memory" {
-            if let cached = state.memoryLOUDS {
-                return cached
+            if state.memoryHasLoaded {
+                return state.memoryLOUDS
             } else if let memoryURL = state.memoryURL,
                       let louds = LOUDS.loadMemory(memoryURL: memoryURL) {
-                state.memoryLOUDS = louds
+                state.updateMemoryLOUDS(louds)
                 return louds
             } else {
+                state.updateMemoryLOUDS(nil)
                 debug("Error: ユーザ辞書のloudsファイルの読み込みに失敗しましたが、このエラーは深刻ではありません。")
             }
         }
@@ -178,23 +180,7 @@ public final class DicdataStore {
             "|": "[7C]"
         ][query, default: query]
 
-        if identifier == "user", let userDictionaryURL = state.userDictionaryURL {
-            if let louds = LOUDS.loadUserDictionary(userDictionaryURL: userDictionaryURL) {
-                self.loudses[query] = louds
-                return louds
-            } else {
-                debug("Error: IDが「\(identifier) (query: \(query))」のloudsファイルの読み込みに失敗しましたが、このエラーは深刻ではありません。")
-                return nil
-            }
-        } else if identifier == "memory", let memoryURL = state.memoryURL {
-            if let louds = LOUDS.loadMemory(memoryURL: memoryURL) {
-                self.loudses[query] = louds
-                return louds
-            } else {
-                debug("Error: IDが「\(identifier) (query: \(query))」のloudsファイルの読み込みに失敗しましたが、このエラーは深刻ではありません。")
-                return nil
-            }
-        } else if let louds = LOUDS.load(identifier, dictionaryURL: self.dictionaryURL) {
+        if let louds = LOUDS.load(identifier, dictionaryURL: self.dictionaryURL) {
             self.loudses[query] = louds
             self.importedLoudses.insert(query)
             return louds

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -300,7 +300,7 @@ public final class DicdataStore {
         if let inputProcessRange, needTypoCorrection {
             let typoCorrectionGenerator = TypoCorrectionGenerator(
                 inputs: composingText.input,
-                range: inputProcessRange,
+                range: inputProcessRange
             )
             generator.register(typoCorrectionGenerator)
         }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -296,11 +296,11 @@ public final class DicdataStore {
             )
             generator.register(surfaceGenerator)
         }
-        if let inputProcessRange {
+        // Register TypoCorrectionGenerator only when typo correction is enabled
+        if let inputProcessRange, needTypoCorrection {
             let typoCorrectionGenerator = TypoCorrectionGenerator(
                 inputs: composingText.input,
                 range: inputProcessRange,
-                needTypoCorrection: needTypoCorrection
             )
             generator.register(typoCorrectionGenerator)
         }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStoreState.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStoreState.swift
@@ -15,13 +15,17 @@ package final class DicdataStoreState {
         self.learningMemoryManager.config.memoryURL
     }
 
-    var userDictionaryLOUDS: LOUDS?
-    var memoryLOUDS: LOUDS?
+    private(set) var userDictionaryHasLoaded: Bool = false
+    private(set) var userDictionaryLOUDS: LOUDS?
+
+    private(set) var memoryHasLoaded: Bool = false
+    private(set) var memoryLOUDS: LOUDS?
 
     func updateUserDictionaryURL(_ newURL: URL) {
         if self.userDictionaryURL != newURL {
             self.userDictionaryURL = newURL
             self.userDictionaryLOUDS = nil
+            self.userDictionaryHasLoaded = false
         }
     }
 
@@ -33,9 +37,19 @@ package final class DicdataStoreState {
         if self.learningMemoryManager.config != newConfig {
             let updated = self.learningMemoryManager.updateConfig(newConfig)
             if updated {
-                self.memoryLOUDS = nil
+                self.resetMemoryLOUDSCache()
             }
         }
+    }
+
+    func updateMemoryLOUDS(_ newLOUDS: LOUDS?) {
+        self.memoryLOUDS = newLOUDS
+        self.memoryHasLoaded = true
+    }
+
+    func updateUserDictionaryLOUDS(_ newLOUDS: LOUDS?) {
+        self.userDictionaryLOUDS = newLOUDS
+        self.userDictionaryHasLoaded = true
     }
 
     @available(*, deprecated, message: "This API is deprecated. Directly update the state instead.")
@@ -55,19 +69,24 @@ package final class DicdataStoreState {
         }
     }
 
+    private func resetMemoryLOUDSCache() {
+        self.memoryLOUDS = nil
+        self.memoryHasLoaded = false
+    }
+
     func saveMemory() {
         self.learningMemoryManager.save()
-        self.memoryLOUDS = nil
+        self.resetMemoryLOUDSCache()
     }
 
     func resetMemory() {
         self.learningMemoryManager.resetMemory()
-        self.memoryLOUDS = nil
+        self.resetMemoryLOUDSCache()
     }
 
     func forgetMemory(_ candidate: Candidate) {
         self.learningMemoryManager.forgetMemory(data: candidate.data)
-        self.memoryLOUDS = nil
+        self.resetMemoryLOUDSCache()
     }
 
     // 学習を反映する

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -130,7 +130,13 @@ final class DicdataStoreTests: XCTestCase {
         for (key, word) in mustWords {
             var c = ComposingText()
             c.insertAtCursorPosition(key, inputStyle: .direct)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: false, state: dicdataStore.prepareState())
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: false,
+                state: dicdataStore.prepareState()
+            )
             // 冗長な書き方だが、こうすることで「どの項目でエラーが発生したのか」がはっきりするため、こう書いている。
             XCTAssertEqual(result.first(where: {$0.data.word == word})?.data.word, word)
         }
@@ -151,7 +157,13 @@ final class DicdataStoreTests: XCTestCase {
         for (key, word) in mustWords {
             var c = ComposingText()
             c.insertAtCursorPosition(key, inputStyle: .direct)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: false, state: dicdataStore.prepareState())
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: false,
+                state: dicdataStore.prepareState()
+            )
             XCTAssertNil(result.first(where: {$0.data.word == word && $0.data.ruby == key}))
         }
     }
@@ -171,7 +183,13 @@ final class DicdataStoreTests: XCTestCase {
         for (key, word) in mustWords {
             var c = ComposingText()
             c.insertAtCursorPosition(key, inputStyle: .direct)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: true, state: dicdataStore.prepareState())
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: true,
+                state: dicdataStore.prepareState()
+            )
             XCTAssertEqual(result.first(where: {$0.data.word == word})?.data.word, word)
         }
     }
@@ -186,7 +204,13 @@ final class DicdataStoreTests: XCTestCase {
         for (key, word) in mustWords {
             var c = ComposingText()
             c.insertAtCursorPosition(key, inputStyle: .roman2kana)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: true, state: dicdataStore.prepareState())
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: true,
+                state: dicdataStore.prepareState()
+            )
             XCTAssertEqual(result.first(where: {$0.data.word == word})?.data.word, word)
         }
     }
@@ -278,7 +302,13 @@ final class DicdataStoreTests: XCTestCase {
         do {
             var c = ComposingText()
             c.insertAtCursorPosition("テストタンゴ", inputStyle: .direct)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: false, state: state)
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: false,
+                state: state
+            )
             XCTAssertTrue(result.contains(where: {$0.data.word == "テスト単語"}))
         }
 
@@ -286,7 +316,13 @@ final class DicdataStoreTests: XCTestCase {
         do {
             var c = ComposingText()
             c.insertAtCursorPosition("ドウテキジショ", inputStyle: .direct)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: false, state: state)
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: false,
+                state: state
+            )
             XCTAssertTrue(result.contains(where: {$0.data.word == "動的辞書"}))
         }
 
@@ -327,7 +363,13 @@ final class DicdataStoreTests: XCTestCase {
         do {
             var c = ComposingText()
             c.insertAtCursorPosition("トクシュヨミ", inputStyle: .direct)
-            let result = dicdataStore.lookupDicdata(composingText: c, inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex), needTypoCorrection: false, state: state)
+            let result = dicdataStore.lookupDicdata(
+                composingText: c,
+                inputRange: (0, c.input.endIndex - 1 ..< c.input.endIndex),
+                surfaceRange: (0, c.convertTarget.count - 1 ..< c.convertTarget.count),
+                needTypoCorrection: false,
+                state: state
+            )
             let dynamicUserDictResult = result.first(where: {$0.data.word == "特殊読み"})
             XCTAssertNotNil(dynamicUserDictResult)
             XCTAssertEqual(dynamicUserDictResult?.data.metadata, .isFromUserDictionary)


### PR DESCRIPTION
#258 の導入後、`loadUserDictionaryLOUDS`の実装ミスのために150%ほど処理負荷が増加していたため、再度最適化した。

さらに、`TypoCorrectionGenerator`を`needTypoCorrection`が`false`の場合には呼ばないようにすることで、デスクトップにおけるZenzai利用時の負荷を25%程度追加で削減した。