### PR TITLE
perf: onlyRomanAlphabetでgetWiseDicdataの処理が低速化していたので回復した

### DIFF
--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -690,7 +690,7 @@ public final class DicdataStore {
             }
         }
         // convertTargetを英単語として候補に追加する
-        if convertTarget.onlyRomanAlphabet && keyboardLanguage == .en_US {
+        if keyboardLanguage == .en_US, convertTarget.onlyRomanAlphabet {
             result.append(DicdataElement(ruby: convertTarget, cid: CIDData.固有名詞.cid, mid: MIDData.英単語.mid, value: -14))
         }
         // convertTargetが1文字のケースでは、ひらがな・カタカナに変換したものを候補に追加する

--- a/Sources/SwiftUtils/StringUtils.swift
+++ b/Sources/SwiftUtils/StringUtils.swift
@@ -17,9 +17,19 @@ extension StringProtocol {
     }
     /// ローマ字のみかどうか
     ///  - note: 空文字列の場合`false`を返す。
+    /// 以前は正規表現ベースで実装していたが、パフォーマンス上良くなかったので直接実装した
     @inlinable
     package var onlyRomanAlphabet: Bool {
-        !isEmpty && range(of: "[^a-zA-Z]", options: .regularExpression) == nil
+        guard !self.isEmpty else {
+            return false
+        }
+        for value in self.utf8 {
+            // 'a' <= value <= 'z' || 'A' <= value <= 'Z'
+            guard 0x61 <= value && value <= 0x7a || 0x41 <= value && value <= 0x5a else {
+                return false
+            }
+        }
+        return true
     }
     /// ローマ字を含むかどうか
     ///  - note: 空文字列の場合`false`を返す。


### PR DESCRIPTION
ZenzaiTests.testGradualConversion_Roman2Kanaで70ms程度の削減になる