### PR TITLE
fix: Zenzaiの利用時、学習候補がリジェクトされた場合の復帰処理が十分でなかったので修正

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -146,7 +146,7 @@ extension Kana2Kanji {
                     let cLen = constraintBytes.count
                     for index in node.prevs.indices {
                         // 学習データやユーザ辞書由来の場合は素通しする
-                        if node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                        if !constraint.ignoreMemoryAndUserDictionary, node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let (matched, total) = mtPerPrev[index]
                             // 最終チェック（EOS時の条件に合わせる）
                             let condition = if constraint.hasEOS {
@@ -186,7 +186,7 @@ extension Kana2Kanji {
                             // 制約 AB 単語 A   (OK)
                             // 制約 AB 単語 AC  (NG)
                             // ただし、学習データやユーザ辞書由来の場合は素通しする
-                            if nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            if !constraint.ignoreMemoryAndUserDictionary, nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                                 let (matchedPrev, totalPrev) = mtPerPrev[index]
                                 // ensure no prior mismatch
                                 guard matchedPrev == min(totalPrev, cLen) else {

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/extension LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/extension LOUDS.swift
@@ -120,7 +120,7 @@ extension LOUDS {
         var ruby: String = ""
         var i = dicdata.startIndex
 
-        binary.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Void in
+        binary.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
             let ptr = rawBuffer.bindMemory(to: UInt8.self).baseAddress!
             let count = binary.count
             var offset = strStart + 1 - binary.startIndex


### PR DESCRIPTION
学習やユーザ辞書の候補はZenzaiの制約付きドラフト生成でも素通しすることになっているが、そのような候補がZenzモデル側でリジェクトされた場合、候補の再探索が上手く行えていなかった。このPRでは問題を修正し、Zenz側でリジェクトされた場合の再探索を適切に行うようにした。