### PR TITLE
feat: 辞書データのファイル名でNON-ASCII文字をエスケープ

### DIFF
--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/DictionaryBuilder.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/DictionaryBuilder.swift
@@ -154,7 +154,8 @@ public enum DictionaryBuilder {
     }
 
     /// Escape a shard identifier string into filesystem-safe fixed-width hex chunks.
-    /// - Encoding: UTF-16 code units represented as 4-hex uppercase, joined by underscores.
+    /// - Encoding: UTF-16 code units represented as 4-hex uppercase, joined by underscores, wrapped in brackets.
+    ///   Example: "あ" -> "[3042]", "AB" -> "[0041_0042]", "🇯🇵" -> "[D83C_DDEF_D83C_DDF5]"
     ///   - BMP scalars: single 4-hex chunk
     ///   - Non-BMP scalars: surrogate pair (two chunks)
     /// - Special cases: "user", "memory", and "user_shortcuts" are returned as-is
@@ -177,7 +178,7 @@ public enum DictionaryBuilder {
                 }
             }
         }
-        return chunks.joined(separator: "_")
+        return "[" + chunks.joined(separator: "_") + "]"
     }
 
     /// High-level: write LOUDS and loudschars2 files atomically to given URLs.
@@ -215,7 +216,7 @@ public enum DictionaryBuilder {
             shards[shard, default: []].append((local: local, ruby: ruby, rows: rows))
         }
         for (shard, items) in shards.sorted(by: { $0.key < $1.key }) {
-            let url = directoryURL.appendingPathComponent("\(id)-\(shard).loudstxt3")
+            let url = directoryURL.appendingPathComponent("\(id)\(shard).loudstxt3")
             try Loudstxt3Builder.writeAligned(items: items, to: url, entriesPerShard: entriesPerShard)
         }
     }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -441,7 +441,7 @@ public final class DicdataStore {
         var data: [DicdataElement] = []
         if identifier == "user", let userDictionaryURL = state.userDictionaryURL {
             for (key, value) in dict {
-                let fileID = "\(identifier)-\(key)"
+                let fileID = "\(identifier)\(key)"
                 data.append(contentsOf: LOUDS.getUserDictionaryDataForLoudstxt3(
                     fileID,
                     indices: value.map { $0 & DictionaryBuilder.localMask },
@@ -455,7 +455,7 @@ public final class DicdataStore {
         }
         if identifier == "user_shortcuts", let userDictionaryURL = state.userDictionaryURL {
             for (key, value) in dict {
-                let fileID = "\(identifier)-\(key)"
+                let fileID = "\(identifier)\(key)"
                 data.append(contentsOf: LOUDS.getUserShortcutsDataForLoudstxt3(
                     fileID,
                     indices: value.map { $0 & DictionaryBuilder.localMask },
@@ -469,7 +469,7 @@ public final class DicdataStore {
         }
         if identifier == "memory", let memoryURL = state.memoryURL {
             for (key, value) in dict {
-                let fileID = "\(identifier)-\(key)"
+                let fileID = "\(identifier)\(key)"
                 data.append(contentsOf: LOUDS.getMemoryDataForLoudstxt3(
                     fileID,
                     indices: value.map { $0 & DictionaryBuilder.localMask },
@@ -482,9 +482,9 @@ public final class DicdataStore {
             }
         }
         for (key, value) in dict {
-            // Default dictionary shards are stored under escaped identifiers with hyphenated shard suffix
+            // Default dictionary shards are stored under escaped identifiers with concatenated shard suffix
             let escaped = DictionaryBuilder.escapedIdentifier(identifier)
-            let fileID = "\(escaped)-\(key)"
+            let fileID = "\(escaped)\(key)"
             data.append(contentsOf: LOUDS.getDataForLoudstxt3(
                 fileID,
                 indices: value.map { $0 & DictionaryBuilder.localMask },

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStore.swift
@@ -441,10 +441,11 @@ public final class DicdataStore {
         var data: [DicdataElement] = []
         if identifier == "user", let userDictionaryURL = state.userDictionaryURL {
             for (key, value) in dict {
+                let fileID = "\(identifier)-\(key)"
                 data.append(contentsOf: LOUDS.getUserDictionaryDataForLoudstxt3(
-                    identifier + "\(key)",
+                    fileID,
                     indices: value.map { $0 & DictionaryBuilder.localMask },
-                    cache: self.loudstxts[identifier + "\(key)"],
+                    cache: self.loudstxts[fileID],
                     userDictionaryURL: userDictionaryURL
                 ))
             }
@@ -454,10 +455,11 @@ public final class DicdataStore {
         }
         if identifier == "user_shortcuts", let userDictionaryURL = state.userDictionaryURL {
             for (key, value) in dict {
+                let fileID = "\(identifier)-\(key)"
                 data.append(contentsOf: LOUDS.getUserShortcutsDataForLoudstxt3(
-                    identifier + "\(key)",
+                    fileID,
                     indices: value.map { $0 & DictionaryBuilder.localMask },
-                    cache: self.loudstxts[identifier + "\(key)"],
+                    cache: self.loudstxts[fileID],
                     userDictionaryURL: userDictionaryURL
                 ))
             }
@@ -467,10 +469,11 @@ public final class DicdataStore {
         }
         if identifier == "memory", let memoryURL = state.memoryURL {
             for (key, value) in dict {
+                let fileID = "\(identifier)-\(key)"
                 data.append(contentsOf: LOUDS.getMemoryDataForLoudstxt3(
-                    identifier + "\(key)",
+                    fileID,
                     indices: value.map { $0 & DictionaryBuilder.localMask },
-                    cache: self.loudstxts[identifier + "\(key)"],
+                    cache: self.loudstxts[fileID],
                     memoryURL: memoryURL
                 ))
             }
@@ -479,10 +482,13 @@ public final class DicdataStore {
             }
         }
         for (key, value) in dict {
+            // Default dictionary shards are stored under escaped identifiers with hyphenated shard suffix
+            let escaped = DictionaryBuilder.escapedIdentifier(identifier)
+            let fileID = "\(escaped)-\(key)"
             data.append(contentsOf: LOUDS.getDataForLoudstxt3(
-                identifier + "\(key)",
+                fileID,
                 indices: value.map { $0 & DictionaryBuilder.localMask },
-                cache: self.loudstxts[identifier + "\(key)"],
+                cache: self.loudstxts[fileID],
                 dictionaryURL: self.dictionaryURL
             ))
         }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/LearningMemory.swift
@@ -53,9 +53,9 @@ struct LongTermLearningMemory {
     }
     private static func loudsTxt3FileURL(_ value: String, asTemporaryFile: Bool, directoryURL: URL) -> URL {
         if asTemporaryFile {
-            return directoryURL.appendingPathComponent("memory\(value).loudstxt3.2", isDirectory: false)
+            return directoryURL.appendingPathComponent("memory-\(value).loudstxt3.2", isDirectory: false)
         } else {
-            return directoryURL.appendingPathComponent("memory\(value).loudstxt3", isDirectory: false)
+            return directoryURL.appendingPathComponent("memory-\(value).loudstxt3", isDirectory: false)
         }
     }
     private static func fileExist(_ url: URL) -> Bool {

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/LearningMemory.swift
@@ -53,9 +53,9 @@ struct LongTermLearningMemory {
     }
     private static func loudsTxt3FileURL(_ value: String, asTemporaryFile: Bool, directoryURL: URL) -> URL {
         if asTemporaryFile {
-            return directoryURL.appendingPathComponent("memory-\(value).loudstxt3.2", isDirectory: false)
+            return directoryURL.appendingPathComponent("memory\(value).loudstxt3.2", isDirectory: false)
         } else {
-            return directoryURL.appendingPathComponent("memory-\(value).loudstxt3", isDirectory: false)
+            return directoryURL.appendingPathComponent("memory\(value).loudstxt3", isDirectory: false)
         }
     }
     private static func fileExist(_ url: URL) -> Bool {

--- a/Tests/KanaKanjiConverterModuleTests/DictionaryBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/DictionaryBuilderTests.swift
@@ -154,7 +154,7 @@ final class DictionaryBuilderTests: XCTestCase {
             return
         }
         let (shard, local) = shardComponents(nodeIndex)
-        let dic = LOUDS.getDataForLoudstxt3("\(escapedA)-\(shard)", indices: [local], dictionaryURL: parent)
+        let dic = LOUDS.getDataForLoudstxt3("\(escapedA)\(shard)", indices: [local], dictionaryURL: parent)
         let words = dic.filter { $0.ruby == "あい" }.map { $0.word }
         XCTAssertTrue(Set(words).isSuperset(of: ["愛", "藍"]))
     }
@@ -253,8 +253,8 @@ final class DictionaryBuilderTests: XCTestCase {
         )
 
         // Files exist with escaped identifiers
-        let escapedSpace = DictionaryBuilder.escapedIdentifier(" ") // 0020
-        let escapedSlash = DictionaryBuilder.escapedIdentifier("/") // 002F
+        let escapedSpace = DictionaryBuilder.escapedIdentifier(" ") // [0020]
+        let escapedSlash = DictionaryBuilder.escapedIdentifier("/") // [002F]
         assertExists(loudsDir.appendingPathComponent("\(escapedSpace).louds"))
         assertExists(loudsDir.appendingPathComponent("\(escapedSlash).louds"))
         // At least shard 0 should exist for both
@@ -274,14 +274,14 @@ final class DictionaryBuilderTests: XCTestCase {
         // Search both entries
         if let idx = loudsSpace.searchNodeIndex(chars: toIDs(" ", cmap)) {
             let (shard, local) = shardComponents(idx)
-            let dic = LOUDS.getDataForLoudstxt3("\(escapedSpace)-\(shard)", indices: [local], dictionaryURL: parent)
+            let dic = LOUDS.getDataForLoudstxt3("\(escapedSpace)\(shard)", indices: [local], dictionaryURL: parent)
             XCTAssertTrue(dic.contains { $0.word == "スペース" && $0.ruby == " " })
         } else {
             XCTFail("space ruby not found in LOUDS")
         }
         if let idx = loudsSlash.searchNodeIndex(chars: toIDs("/", cmap)) {
             let (shard, local) = shardComponents(idx)
-            let dic = LOUDS.getDataForLoudstxt3("\(escapedSlash)-\(shard)", indices: [local], dictionaryURL: parent)
+            let dic = LOUDS.getDataForLoudstxt3("\(escapedSlash)\(shard)", indices: [local], dictionaryURL: parent)
             XCTAssertTrue(dic.contains { $0.word == "スラッシュ" && $0.ruby == "/" })
         } else {
             XCTFail("slash ruby not found in LOUDS")

--- a/Tests/KanaKanjiConverterModuleTests/DictionaryBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/DictionaryBuilderTests.swift
@@ -112,7 +112,7 @@ final class DictionaryBuilderTests: XCTestCase {
                 continue
             }
             let (shard, local) = shardComponents(nodeIndex)
-            let dic = LOUDS.getUserDictionaryDataForLoudstxt3("user-\(shard)", indices: [local], userDictionaryURL: dir)
+            let dic = LOUDS.getUserDictionaryDataForLoudstxt3("user\(shard)", indices: [local], userDictionaryURL: dir)
             let words = dic.filter { $0.ruby == ruby }.map { $0.word }
             XCTAssertFalse(words.isEmpty, "No words for ruby \(ruby)")
         }
@@ -142,7 +142,7 @@ final class DictionaryBuilderTests: XCTestCase {
         // Only test first-character shard "あ" which should exist
         // Filenames are escaped; load via escaped identifier (UTF-16 hex chunks)
         let escapedA = DictionaryBuilder.escapedIdentifier("あ")
-        XCTAssertEqual(escapedA, "3042")
+        XCTAssertEqual(escapedA, "[3042]")
         guard let loudsA = LOUDS.load(escapedA, dictionaryURL: parent) else {
             XCTFail("Failed to load sharded LOUDS for あ")
             return
@@ -258,8 +258,8 @@ final class DictionaryBuilderTests: XCTestCase {
         assertExists(loudsDir.appendingPathComponent("\(escapedSpace).louds"))
         assertExists(loudsDir.appendingPathComponent("\(escapedSlash).louds"))
         // At least shard 0 should exist for both
-        assertExists(loudsDir.appendingPathComponent("\(escapedSpace)-0.loudstxt3"))
-        assertExists(loudsDir.appendingPathComponent("\(escapedSlash)-0.loudstxt3"))
+        assertExists(loudsDir.appendingPathComponent("\(escapedSpace)0.loudstxt3"))
+        assertExists(loudsDir.appendingPathComponent("\(escapedSlash)0.loudstxt3"))
 
         // Loading via DicdataStore with raw identifiers should resolve using escape mapping
         let store = DicdataStore(dictionaryURL: parent)
@@ -360,7 +360,7 @@ final class DictionaryBuilderTests: XCTestCase {
             let shard = idx / 1024
             let local = idx % 1024
             // Verify header count of the written file is 1024
-            let url = dir.appendingPathComponent("user-\(shard).loudstxt3")
+            let url = dir.appendingPathComponent("user\(shard).loudstxt3")
             let data = try Data(contentsOf: url)
             XCTAssertEqual(headerCount(data), 1024)
             // Parse by helper (matches writer’s alignment)
@@ -374,28 +374,28 @@ final class DictionaryBuilderTests: XCTestCase {
 
     // MARK: - escapedIdentifier tests (migrated from EscapedIdentifierTests)
     func testEscapedIdentifierAsciiLetters() {
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("a"), "0061")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("A"), "0041")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("z"), "007A")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("Z"), "005A")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("a"), "[0061]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("A"), "[0041]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("z"), "[007A]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("Z"), "[005A]")
     }
 
     func testEscapedIdentifierAsciiSymbolsAndSpace() {
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier(" "), "0020")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("/"), "002F")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("\\"), "005C")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("\n"), "000A")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier(" "), "[0020]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("/"), "[002F]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("\\"), "[005C]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("\n"), "[000A]")
     }
 
     func testEscapedIdentifierHiraganaKatakanaKanji() {
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("あ"), "3042")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("ア"), "30A2")
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("漢"), "6F22")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("あ"), "[3042]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("ア"), "[30A2]")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("漢"), "[6F22]")
     }
 
     func testEscapedIdentifierMultiScalarEmojiFlag() {
         // 🇯🇵 = U+1F1EF U+1F1F5 -> UTF-16: D83C DDEF D83C DDF5
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("🇯🇵"), "D83C_DDEF_D83C_DDF5")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier("🇯🇵"), "[D83C_DDEF_D83C_DDF5]")
     }
 
     func testEscapedIdentifierReservedIdentifiersRemainUnchanged() {
@@ -405,6 +405,6 @@ final class DictionaryBuilderTests: XCTestCase {
     }
 
     func testEscapedIdentifierEmptyString() {
-        XCTAssertEqual(DictionaryBuilder.escapedIdentifier(""), "")
+        XCTAssertEqual(DictionaryBuilder.escapedIdentifier(""), "[]")
     }
 }


### PR DESCRIPTION
fix #259 

辞書データのファイル名に関する大きなbreaking changeであることに留意してください。