### PR TITLE
fix: lattice indexの取り扱いを修正

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
@@ -64,11 +64,13 @@ struct LatticeDualIndexMap: Sendable {
         var sIndexPointer = 0
         for i in 0 ..< inputCount {
             if let sIndex = self.inputIndexToSurfaceIndexMap[i] {
-                for j in min(surfaceCount, sIndexPointer) ..< min(surfaceCount, sIndex) {
+                for j in min(sIndexPointer, sIndex) ..< sIndex {
                     indices.append(.surfaceIndex(j))
                 }
-                if i < inputCount && sIndex < surfaceCount {
+                if sIndexPointer <= sIndex, sIndex < surfaceCount {
                     indices.append(.bothIndex(inputIndex: i, surfaceIndex: sIndex))
+                } else {
+                    indices.append(.inputIndex(i))
                 }
                 sIndexPointer = sIndex + 1
             } else {

--- a/Tests/KanaKanjiConverterModuleTests/ComposingTextTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ComposingTextTests.swift
@@ -127,7 +127,7 @@ final class ComposingTextTests: XCTestCase {
                 ComposingText.InputElement(character: "n", inputStyle: .roman2kana),
                 ComposingText.InputElement(piece: .compositionSeparator, inputStyle: .frozen),
                 ComposingText.InputElement(character: "n", inputStyle: .roman2kana),
-                ComposingText.InputElement(character: "a", inputStyle: .roman2kana),
+                ComposingText.InputElement(character: "a", inputStyle: .roman2kana)
             ])
             XCTAssertEqual(c.convertTargetCursorPosition, 3)
         }
@@ -144,7 +144,7 @@ final class ComposingTextTests: XCTestCase {
                 ComposingText.InputElement(character: "k", inputStyle: .roman2kana),
                 ComposingText.InputElement(piece: .compositionSeparator, inputStyle: .frozen),
                 ComposingText.InputElement(character: "n", inputStyle: .roman2kana),
-                ComposingText.InputElement(character: "a", inputStyle: .roman2kana),
+                ComposingText.InputElement(character: "a", inputStyle: .roman2kana)
             ])
             XCTAssertEqual(c.convertTargetCursorPosition, 2)
             c.insertAtCursorPosition("a", inputStyle: .roman2kana)
@@ -156,7 +156,7 @@ final class ComposingTextTests: XCTestCase {
                 ComposingText.InputElement(character: "a", inputStyle: .roman2kana),
                 ComposingText.InputElement(piece: .compositionSeparator, inputStyle: .frozen),
                 ComposingText.InputElement(character: "n", inputStyle: .roman2kana),
-                ComposingText.InputElement(character: "a", inputStyle: .roman2kana),
+                ComposingText.InputElement(character: "a", inputStyle: .roman2kana)
             ])
             XCTAssertEqual(c.convertTargetCursorPosition, 2)
         }
@@ -191,7 +191,7 @@ final class ComposingTextTests: XCTestCase {
                 ComposingText.InputElement(character: "k", inputStyle: .roman2kana),
                 ComposingText.InputElement(piece: .compositionSeparator, inputStyle: .frozen),
                 ComposingText.InputElement(character: "y", inputStyle: .roman2kana),
-                ComposingText.InputElement(character: "a", inputStyle: .roman2kana),
+                ComposingText.InputElement(character: "a", inputStyle: .roman2kana)
             ])
             XCTAssertEqual(c.convertTarget, "kや")   // 「きゃ」にはならない
             XCTAssertEqual(c.convertTargetCursorPosition, 2)
@@ -363,6 +363,21 @@ final class ComposingTextTests: XCTestCase {
             XCTAssertEqual(map[5], nil)   // i
             XCTAssertEqual(map[6], 2)     // u
             XCTAssertEqual(map[7], 3)     // e
+        }
+        do {
+            // ローマ字
+            InputStyleManager.registerInputStyle(table: InputTable(baseMapping: [
+                [.piece(.character("k")), .piece(.character("i"))]: [],
+                [.piece(.character("a"))]: [.character("あ")]
+            ]), for: "test-empty-ki")
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "ki", inputStyle: .mapped(id: .tableName("test-empty-ki")))
+            XCTAssertEqual(c.convertTarget, "")
+            XCTAssertEqual(c.input.count, 2)
+            let map = c.inputIndexToSurfaceIndexMap()
+            XCTAssertEqual(map[0], 0)     // ""
+            XCTAssertEqual(map[1], nil)   // k
+            XCTAssertEqual(map[2], 0)     // i
         }
         // 逆引き
         do {

--- a/Tests/KanaKanjiConverterModuleTests/LatticeTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/LatticeTests.swift
@@ -1,0 +1,95 @@
+@testable import KanaKanjiConverterModule
+import XCTest
+
+final class LatticeTests: XCTestCase {
+    func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: InputStyle) {
+        for char in sequence {
+            composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
+        }
+    }
+
+    func testDualIndexMap() throws {
+        // ローマ字
+        do {
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "kyakkansi", inputStyle: .roman2kana)
+            let latticeDualIndexMap = LatticeDualIndexMap(c)
+            let indices = Array(latticeDualIndexMap.indices(inputCount: c.input.count, surfaceCount: c.convertTarget.count))
+            XCTAssertEqual(indices[0], .bothIndex(inputIndex: 0, surfaceIndex: 0))     // ""
+            XCTAssertEqual(indices[1], .inputIndex(1))     // k
+            XCTAssertEqual(indices[2], .inputIndex(2))     // ky
+            XCTAssertEqual(indices[3], .surfaceIndex(1))     // "きゃ"
+            XCTAssertEqual(indices[4], .bothIndex(inputIndex: 3, surfaceIndex: 2))  // きゃ
+            XCTAssertEqual(indices[5], .inputIndex(4))  // kyak
+            XCTAssertEqual(indices[6], .inputIndex(5))  // kyakk
+            XCTAssertEqual(indices[7], .surfaceIndex(3))  // きゃっ
+            XCTAssertEqual(indices[8], .bothIndex(inputIndex: 6, surfaceIndex: 4))  // きゃっか
+            XCTAssertEqual(indices[9], .inputIndex(7))  // kyakkan
+            XCTAssertEqual(indices[10], .inputIndex(8))  // kyakkans
+            XCTAssertEqual(indices[11], .surfaceIndex(5))  // きゃっかん
+            XCTAssertEqual(indices.count, 12)  // 末尾は取り扱わない
+        }
+        // ローマ字
+        do {
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "kan", inputStyle: .roman2kana)
+            c.insertAtCursorPosition([.init(piece: .compositionSeparator, inputStyle: .roman2kana)])
+            let latticeDualIndexMap = LatticeDualIndexMap(c)
+            let indices = Array(latticeDualIndexMap.indices(inputCount: c.input.count, surfaceCount: c.convertTarget.count))
+            XCTAssertEqual(indices[0], .bothIndex(inputIndex: 0, surfaceIndex: 0))     // ""
+            XCTAssertEqual(indices[1], .inputIndex(1))     // k
+            XCTAssertEqual(indices[2], .bothIndex(inputIndex: 2, surfaceIndex: 1))     // ka
+            XCTAssertEqual(indices[3], .inputIndex(3))     // "kan"
+            XCTAssertEqual(indices.count, 4)  // 末尾は取り扱わない
+        }
+        // ローマ字
+        do {
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "kan", inputStyle: .roman2kana)
+            c.insertAtCursorPosition([.init(piece: .compositionSeparator, inputStyle: .roman2kana)])
+            sequentialInput(&c, sequence: "i", inputStyle: .roman2kana)
+            let latticeDualIndexMap = LatticeDualIndexMap(c)
+            let indices = Array(latticeDualIndexMap.indices(inputCount: c.input.count, surfaceCount: c.convertTarget.count))
+            XCTAssertEqual(indices[0], .bothIndex(inputIndex: 0, surfaceIndex: 0))     // ""
+            XCTAssertEqual(indices[1], .inputIndex(1))     // k
+            XCTAssertEqual(indices[2], .bothIndex(inputIndex: 2, surfaceIndex: 1))     // ka
+            XCTAssertEqual(indices[3], .inputIndex(3))     // "kan"
+            XCTAssertEqual(indices[4], .bothIndex(inputIndex: 4, surfaceIndex: 2))     // "かん"
+            XCTAssertEqual(indices.count, 5)  // 末尾は取り扱わない
+        }
+        // ローマ字
+        do {
+            InputStyleManager.registerInputStyle(table: InputTable(baseMapping: [
+                [.piece(.character("k")), .piece(.character("i"))]: [],
+                [.piece(.character("a"))]: [.character("あ")]
+            ]), for: "test")
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "ki", inputStyle: .mapped(id: .tableName("test")))
+            XCTAssertEqual(c.convertTarget, "")
+            XCTAssertEqual(c.input.count, 2)
+            do {
+                let latticeDualIndexMap = LatticeDualIndexMap(c)
+                let indices = Array(latticeDualIndexMap.indices(inputCount: c.input.count, surfaceCount: c.convertTarget.count))
+                XCTAssertEqual(indices[0], .inputIndex(0))     // "k-"
+                XCTAssertEqual(indices[1], .inputIndex(1))     // "i-"
+                XCTAssertEqual(indices.count, 2)  // 末尾は取り扱わない
+            }
+            sequentialInput(&c, sequence: "a", inputStyle: .mapped(id: .tableName("test")))
+            XCTAssertEqual(c.convertTarget, "あ")
+            XCTAssertEqual(c.input.count, 3)
+            do {
+                let latticeDualIndexMap = LatticeDualIndexMap(c)
+                let map = c.inputIndexToSurfaceIndexMap()
+                XCTAssertEqual(map[0], 0)     // ""
+                XCTAssertEqual(map[1], 1)     // a-
+                XCTAssertEqual(map[2], nil)     // a-
+                XCTAssertEqual(map.count, 3)  // 末尾は取り扱わない
+                let indices = Array(latticeDualIndexMap.indices(inputCount: c.input.count, surfaceCount: c.convertTarget.count))
+                XCTAssertEqual(indices[0], .bothIndex(inputIndex: 0, surfaceIndex: 0))     // ""
+                XCTAssertEqual(indices[1], .inputIndex(1))     // a-
+                XCTAssertEqual(indices[2], .inputIndex(2))     // a-
+                XCTAssertEqual(indices.count, 3)  // 末尾は取り扱わない
+            }
+        }
+    }
+}

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
@@ -315,6 +315,29 @@ final class ConverterTests: XCTestCase {
         }
     }
 
+    func testInputTableEdgeCases() throws {
+        do {
+            let converter = KanaKanjiConverter.withDefaultDictionary()
+            InputStyleManager.registerInputStyle(table: InputTable(baseMapping: [
+                [.piece(.character("k")), .piece(.character("i"))]: [],
+                [.piece(.character("a"))]: [.character("あ")]
+            ]), for: "test")
+            var c = ComposingText()
+            sequentialInput(&c, sequence: "ki", inputStyle: .mapped(id: .tableName("test")))
+            XCTAssertEqual(c.convertTarget, "")
+            XCTAssertEqual(c.input.count, 2)
+            do {
+                let results = converter.requestCandidates(c, options: requestOptions())
+                XCTAssertTrue(results.mainResults.isEmpty)
+            }
+            sequentialInput(&c, sequence: "a", inputStyle: .mapped(id: .tableName("test")))
+            do {
+                let results = converter.requestCandidates(c, options: requestOptions())
+                XCTAssertTrue(results.mainResults.contains(where: {$0.text == "あ"}))
+            }
+        }
+    }
+
     // 必ず正解すべきテストケース
     func testMustCases() async throws {
         // ダイレクト入力


### PR DESCRIPTION
`ki -> ""`のようなルールが存在する場合を上手く取り扱えていなかったので`indices`の実装を修正した。