### PR TITLE
perf: optimize Zenzai CPU inference and conversion memory

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        # Swift 6.1.3 cannot import the Xcode 26 SDK currently selected by macos-latest.
+        # macos-15 uses Xcode 16.4, whose SDK is compatible with this toolchain.
+        os: [macos-15]
         # setup-swift on macOS currently rejects a 6.1 request when the runner resolves to 6.1.3.
         swift-version: ["6.1.3"]
     steps:

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
@@ -17,7 +17,12 @@ public final class LatticeNode {
     /// `prevs`の各要素に対応するスコアのデータ
     var values: [PValue] = []
     /// inputData.input内のrange
-    var range: Lattice.LatticeRange
+    var range: Lattice.LatticeRange {
+        didSet {
+            self.registeredNodePayload = nil
+        }
+    }
+    private var registeredNodePayload: RegisteredNodePayload?
 
     /// `EOS`に対応するノード。
     static var EOSNode: LatticeNode {
@@ -33,7 +38,14 @@ public final class LatticeNode {
     /// `LatticeNode`の持っている情報を反映した`RegisteredNode`を作成する
     /// `LatticeNode`は複数の過去のノードを持つことができるが、`RegisteredNode`は1つしか持たない。
     func getRegisteredNode(_ index: Int, value: PValue) -> RegisteredNode {
-        RegisteredNode(data: self.data, registered: self.prevs[index], totalValue: value, range: self.range)
+        let payload: RegisteredNodePayload
+        if let registeredNodePayload {
+            payload = registeredNodePayload
+        } else {
+            payload = RegisteredNodePayload(data: self.data, range: self.range)
+            self.registeredNodePayload = payload
+        }
+        return RegisteredNode(payload: payload, registered: self.prevs[index], totalValue: value)
     }
 
     /// 再帰的にノードを遡り、`CandidateData`を構築する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
@@ -1,15 +1,27 @@
 import Foundation
 
-/// `indirect enum`を用いて再帰的なノード構造を実現
+/// N-bestの複数経路で共通する辞書データと入力範囲を1回だけ保持する。
+final class RegisteredNodePayload {
+    init(data: consuming DicdataElement, range: Lattice.LatticeRange) {
+        self.data = data
+        self.range = range
+    }
+
+    let data: DicdataElement
+    let range: Lattice.LatticeRange
+}
+
+/// `indirect enum`を用いて再帰的なノード構造を実現する。
+/// 辞書データと入力範囲は、同じLatticeNodeから派生したN-best経路間で共有する。
 indirect enum RegisteredNode {
-    case node(data: DicdataElement, prev: RegisteredNode?, totalValue: PValue, range: Lattice.LatticeRange)
+    case node(payload: RegisteredNodePayload, prev: RegisteredNode?, totalValue: PValue)
 
     /// このノードが保持する辞書データ
     var data: DicdataElement {
         _read {
             switch self {
-            case .node(let data, _, _, _):
-                yield data
+            case .node(let payload, _, _):
+                yield payload.data
             }
         }
     }
@@ -18,7 +30,7 @@ indirect enum RegisteredNode {
     var prev: RegisteredNode? {
         _read {
             switch self {
-            case .node(_, let prev, _, _):
+            case .node(_, let prev, _):
                 yield prev
             }
         }
@@ -27,7 +39,7 @@ indirect enum RegisteredNode {
     /// 始点からこのノードまでのコスト
     var totalValue: PValue {
         switch self {
-        case .node(_, _, let totalValue, _):
+        case .node(_, _, let totalValue):
             return totalValue
         }
     }
@@ -35,13 +47,21 @@ indirect enum RegisteredNode {
     /// `composingText`の`input`で対応する範囲
     var range: Lattice.LatticeRange {
         switch self {
-        case .node(_, _, _, let range):
-            return range
+        case .node(let payload, _, _):
+            return payload.range
         }
     }
 
     init(data: DicdataElement, registered: RegisteredNode?, totalValue: PValue, range: Lattice.LatticeRange) {
-        self = .node(data: data, prev: registered, totalValue: totalValue, range: range)
+        self = .node(
+            payload: RegisteredNodePayload(data: data, range: range),
+            prev: registered,
+            totalValue: totalValue
+        )
+    }
+
+    init(payload: RegisteredNodePayload, registered: RegisteredNode?, totalValue: PValue) {
+        self = .node(payload: payload, prev: registered, totalValue: totalValue)
     }
 
     /// 始点ノードを生成する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -19,6 +19,64 @@ enum CandidateEvaluationResult: Sendable, Equatable, Hashable {
     }
 }
 
+struct ZenzEvaluationCacheKey: Sendable, Equatable, Hashable {
+    struct CandidateSegment: Sendable, Equatable, Hashable {
+        var word: String
+        var ruby: String
+        var isLearned: Bool
+    }
+
+    var prompt: String
+    var candidateTextForEvaluation: String
+    var originalCandidateText: String
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+    var requestRichCandidates: Bool
+    var reusesAddressedPrefix: Bool
+    var candidateSegments: [CandidateSegment]
+}
+
+/// モデル評価結果を少量だけ保持する、スレッドセーフなLRUキャッシュ。
+final class ZenzEvaluationCache: @unchecked Sendable {
+    private struct Entry {
+        var result: CandidateEvaluationResult
+        var accessIndex: UInt64
+    }
+
+    init(capacity: Int) {
+        self.capacity = max(1, capacity)
+    }
+
+    func value(for key: ZenzEvaluationCacheKey) -> CandidateEvaluationResult? {
+        self.lock.withLock {
+            guard var entry = self.entries[key] else {
+                return nil
+            }
+            self.accessIndex &+= 1
+            entry.accessIndex = self.accessIndex
+            self.entries[key] = entry
+            return entry.result
+        }
+    }
+
+    func insert(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
+        self.lock.withLock {
+            self.accessIndex &+= 1
+            if self.entries[key] == nil, self.entries.count >= self.capacity,
+               let leastRecentlyUsedKey = self.entries.min(by: {
+                   $0.value.accessIndex < $1.value.accessIndex
+               })?.key {
+                self.entries[leastRecentlyUsedKey] = nil
+            }
+            self.entries[key] = Entry(result: result, accessIndex: self.accessIndex)
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [ZenzEvaluationCacheKey: Entry] = [:]
+    private var accessIndex: UInt64 = 0
+    private let lock = NSLock()
+}
+
 struct ZenzCandidateEvaluator {
     static func evaluate(
         context: ZenzContext,
@@ -48,15 +106,46 @@ struct ZenzCandidateEvaluator {
             versionDependentConfig: versionDependentConfig
         )
         let normalizedPrompt = context.normalizeForModel(prompt)
-        let promptTokens = context.encode(prompt, addBOS: true, addEOS: false)
+        let prevPrompt = context.previousEvaluationPrompt()
+        let reusesAddressedPrefix = prevPrompt == normalizedPrompt && !requestRichCandidates
+        // A cache hit must produce the same subsequent incremental-evaluation state
+        // as a model evaluation.
         defer {
-            context.setPreviousEvaluationPromptTokens(promptTokens)
+            context.setPreviousEvaluationPrompt(normalizedPrompt)
         }
-        let prevPrompt = context.previousEvaluationPromptTokens()
+        let cacheKey: ZenzEvaluationCacheKey? = if personalizationMode == nil {
+            ZenzEvaluationCacheKey(
+                prompt: prompt,
+                candidateTextForEvaluation: candidateTextForEvaluation,
+                originalCandidateText: candidate.text,
+                prefixConstraint: prefixConstraint,
+                requestRichCandidates: requestRichCandidates,
+                reusesAddressedPrefix: reusesAddressedPrefix,
+                candidateSegments: candidate.data.map {
+                    .init(
+                        word: $0.word,
+                        ruby: $0.ruby,
+                        isLearned: $0.metadata.contains(.isLearned)
+                    )
+                }
+            )
+        } else {
+            nil
+        }
+        if let cacheKey, let cached = context.cachedEvaluation(for: cacheKey) {
+            return cached
+        }
+        func finish(_ result: CandidateEvaluationResult) -> CandidateEvaluationResult {
+            if let cacheKey, result != .error {
+                context.cacheEvaluation(result, for: cacheKey)
+            }
+            return result
+        }
 
+        let promptTokens = context.encodeEvaluationPrompt(prompt)
         let candidateTokens = context.encode(candidateTextForEvaluation, addBOS: false, addEOS: false)
         let addressedTokens: [llama_token]
-        if prevPrompt == promptTokens, !requestRichCandidates {
+        if reusesAddressedPrefix {
             var prefix = ""
             for character in candidate.text {
                 let newPrefix = prefix + String(character)
@@ -154,7 +243,7 @@ struct ZenzCandidateEvaluator {
                     let data = Data(cchars.map { UInt8(bitPattern: $0) })
                     let string = String(data: data, encoding: .utf8) ?? ""
                     let wholeResult = String(string.dropFirst(normalizedPrompt.count))
-                    return .wholeResult(wholeResult)
+                    return finish(.wholeResult(wholeResult))
                 } else {
                     let actualLogp = logits[startIndex + Int(tokenID)] - logsumexp
                     let preferLearnedToken = isLearnedToken[i].isLearned && actualLogp + isLearnedToken[i].priority > maxItem.logprob
@@ -162,7 +251,11 @@ struct ZenzCandidateEvaluator {
                         let cchars = tokens[..<i].reduce(into: []) {
                             $0.append(contentsOf: context.tokenToPiece(token: $1))
                         } + context.tokenToPiece(token: maxItem.token)
-                        return .fixRequired(prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init))
+                        return finish(
+                            .fixRequired(
+                                prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                            )
+                        )
                     }
                 }
             } else if !tokenHeap.isEmpty {
@@ -183,11 +276,13 @@ struct ZenzCandidateEvaluator {
             }
             score += maxItem.logprob
         }
-        return .pass(
-            score: score,
-            alternativeConstraints: altTokens.unordered.sorted(by: >).map {
-                .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
-            }
+        return finish(
+            .pass(
+                score: score,
+                alternativeConstraints: altTokens.unordered.sorted(by: >).map {
+                    .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
+                }
+            )
         )
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -2,6 +2,9 @@
 // Zenzai/ZenzaiCPU が有効でない場合、llama-mock.swift の実装が利用される
 import llama
 #endif
+#if canImport(Darwin)
+import Darwin
+#endif
 
 import Algorithms
 import Foundation
@@ -21,73 +24,207 @@ enum ZenzError: LocalizedError {
     }
 }
 
+/// llama.cpp のバックエンドはプロセス単位で一度だけ初期化する。
+///
+/// `llama_backend_free()` は現在 MPI 用の後始末にしか使われないため、モデルや
+/// コンテキストより先に解放される可能性があるプロセス終了時の明示解放は行わない。
+private enum ZenzBackend {
+    private static let initialized: Void = {
+        llama_backend_init()
+    }()
+
+    static func initializeIfNeeded() {
+        _ = self.initialized
+    }
+}
+
+private final class ZenzTokenArrayBox {
+    init(_ tokens: [llama_token]) {
+        self.tokens = tokens
+    }
+
+    let tokens: [llama_token]
+}
+
+/// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
+///
+/// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
+/// 共有することで、同じモデルを利用するConverterごとの再ロードを避ける。
+private final class SharedZenzModel {
+    init(path: String) throws {
+        ZenzBackend.initializeIfNeeded()
+        var modelParams = llama_model_default_params()
+        modelParams.use_mmap = true
+        #if ZenzaiCPU
+        modelParams.n_gpu_layers = 0
+        modelParams.split_mode = LLAMA_SPLIT_MODE_NONE
+        guard let cpuDevice = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU) else {
+            debug("Could not find CPU backend")
+            throw ZenzError.couldNotLoadModel(path: path)
+        }
+        // NULL終端のCPU-onlyデバイスリストを渡す。`n_gpu_layers = 0`だけでは
+        // llama.cppがMetalデバイスも列挙し、context生成時に初期化してしまう。
+        var devices = [cpuDevice, nil]
+        let loadedModel = devices.withUnsafeMutableBufferPointer { buffer in
+            modelParams.devices = buffer.baseAddress
+            return llama_model_load_from_file(path, modelParams)
+        }
+        #else
+        let loadedModel = llama_model_load_from_file(path, modelParams)
+        #endif
+        guard let model = loadedModel else {
+            debug("Could not load model at \(path)")
+            throw ZenzError.couldNotLoadModel(path: path)
+        }
+        guard let vocab = llama_model_get_vocab(model) else {
+            llama_model_free(model)
+            debug("Could not load vocab!")
+            throw ZenzError.couldNotLoadVocab
+        }
+        self.model = model
+        self.vocab = vocab
+        self.evaluationCache = ZenzEvaluationCache(capacity: 256)
+        self.evaluationPromptTokenCache.countLimit = 128
+    }
+
+    deinit {
+        llama_model_free(self.model)
+    }
+
+    let model: OpaquePointer
+    let vocab: OpaquePointer
+    let evaluationCache: ZenzEvaluationCache
+    let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
+}
+
+/// 同時に強参照するモデルを1個に制限する、プロセス共通のモデルキャッシュ。
+///
+/// `NSCache`にすることでメモリプレッシャー時にはモデルを解放できる。呼び出し側の
+/// `ZenzContext`もモデルを強参照するため、使用中のモデルが解放されることはない。
+private final class SharedZenzModelCache: @unchecked Sendable {
+    static let shared = SharedZenzModelCache()
+
+    private init() {
+        self.cache.countLimit = 1
+    }
+
+    func model(path: String) throws -> SharedZenzModel {
+        try self.lock.withLock {
+            let key = path as NSString
+            if let cached = self.cache.object(forKey: key) {
+                return cached
+            }
+            let model = try SharedZenzModel(path: path)
+            self.cache.setObject(model, forKey: key)
+            return model
+        }
+    }
+
+    private let cache = NSCache<NSString, SharedZenzModel>()
+    private let lock = NSLock()
+}
+
 final class ZenzContext {
-    private var model: OpaquePointer
+    private let sharedModel: SharedZenzModel
     private var context: OpaquePointer
-    private var vocab: OpaquePointer
+    private var batch: llama_batch
     private var prevInputBySeq: [llama_seq_id: [llama_token]] = [:]
-    private var prevPromptBySeq: [llama_seq_id: [llama_token]] = [:]
+    private var prevPromptBySeq: [llama_seq_id: String] = [:]
+    private var evaluationPromptTokenCache: (prompt: String, tokens: [llama_token])?
 
     private let n_len: Int32 = 512
     private let evalSeqId: llama_seq_id = 0
     private let inputPredictionSeqId: llama_seq_id = 1
 
-    init(model: OpaquePointer, context: OpaquePointer, vocab: OpaquePointer) {
-        self.model = model
+    private init(sharedModel: SharedZenzModel, context: OpaquePointer) {
+        self.sharedModel = sharedModel
         self.context = context
-        self.vocab = vocab
+        self.batch = llama_batch_init(512, 0, 1)
     }
 
     deinit {
+        llama_batch_free(self.batch)
         llama_free(context)
-        llama_model_free(model)
-        llama_backend_free()
     }
 
     private static var ctx_params: llama_context_params {
-        let n_threads = max(1, min(8, ProcessInfo.processInfo.processorCount - 2))
+        let n_threads = self.inferenceThreadCount
         debug("Using \(n_threads) threads")
         var ctx_params = llama_context_default_params()
         ctx_params.n_ctx = 512
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
+        ctx_params.flash_attn = true
         return ctx_params
     }
 
-    static func createContext(path: String) throws -> ZenzContext {
-        llama_backend_init()
-        var model_params = llama_model_default_params()
-        model_params.use_mmap = true
-        #if ZenzaiCPU
-        // CPU 専用: GPU へのオフロードを無効化
-        model_params.n_gpu_layers = 0
-        model_params.split_mode = LLAMA_SPLIT_MODE_NONE
+    /// 対話的な推論に使うCPUスレッド数を実行環境のトポロジーから決定する。
+    ///
+    /// Apple Siliconでは性能の異なるクラスタを跨ぐと短いdecodeのbarrier待ちが
+    /// 増えるため、最高性能クラスタの物理コア数を利用する。それ以外の環境では
+    /// OSへ応答性の余地を残しつつ、llama.cppの小規模モデルで過剰並列にならない
+    /// よう8スレッドを上限とする。
+    private static var inferenceThreadCount: Int {
+        let activeProcessorCount = max(1, ProcessInfo.processInfo.activeProcessorCount)
+        #if canImport(Darwin)
+        let performanceCoreCount = self.sysctlInt32("hw.perflevel0.physicalcpu")
+        #else
+        let performanceCoreCount: Int? = nil
         #endif
-        let model = llama_model_load_from_file(path, model_params)
-        guard let model else {
-            debug("Could not load model at \(path)")
-            throw ZenzError.couldNotLoadModel(path: path)
-        }
+        return self.selectInferenceThreadCount(
+            activeProcessorCount: activeProcessorCount,
+            performanceCoreCount: performanceCoreCount
+        )
+    }
 
+    /// DarwinではmacOS/iOSともに最高性能クラスタを優先し、sysctl値を取得できない
+    /// 端末やDarwin以外では論理CPU数から安全なフォールバックを選ぶ。
+    static func selectInferenceThreadCount(
+        activeProcessorCount: Int,
+        performanceCoreCount: Int?
+    ) -> Int {
+        let activeProcessorCount = max(1, activeProcessorCount)
+        if let performanceCoreCount,
+           performanceCoreCount > 0,
+           performanceCoreCount <= activeProcessorCount {
+            return performanceCoreCount
+        }
+        let reservedProcessorCount = if activeProcessorCount >= 8 {
+            2
+        } else if activeProcessorCount >= 4 {
+            1
+        } else {
+            0
+        }
+        return max(1, min(8, activeProcessorCount - reservedProcessorCount))
+    }
+
+    #if canImport(Darwin)
+    private static func sysctlInt32(_ name: String) -> Int? {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        guard sysctlbyname(name, &value, &size, nil, 0) == 0, size == MemoryLayout<Int32>.size else {
+            return nil
+        }
+        return Int(value)
+    }
+    #endif
+
+    static func createContext(path: String) throws -> ZenzContext {
+        let sharedModel = try SharedZenzModelCache.shared.model(path: path)
         var params = ctx_params
         #if ZenzaiCPU
         // CPU 専用: KV / KQV 等の GPU オフロードを完全に無効化
         params.offload_kqv = false
         #endif
-        let context = llama_init_from_model(model, params)
+        let context = llama_init_from_model(sharedModel.model, params)
         guard let context else {
             debug("Could not load context!")
             throw ZenzError.couldNotLoadContext
         }
 
-        let vocab = llama_model_get_vocab(model)
-        guard let vocab else {
-            debug("Could not load vocab!")
-            throw ZenzError.couldNotLoadVocab
-        }
-
-        return ZenzContext(model: model, context: context, vocab: vocab)
+        return ZenzContext(sharedModel: sharedModel, context: context)
     }
 
     func resetContext() throws {
@@ -96,7 +233,7 @@ final class ZenzContext {
         #if ZenzaiCPU
         params.offload_kqv = false
         #endif
-        let context = llama_init_from_model(self.model, params)
+        let context = llama_init_from_model(self.sharedModel.model, params)
         guard let context else {
             debug("Could not load context!")
             throw ZenzError.couldNotLoadContext
@@ -143,18 +280,17 @@ final class ZenzContext {
             llama_kv_cache_seq_rm(context, seqId, llama_pos(prefixCacheCount), -1)
             debug("new pos max:", llama_kv_cache_seq_pos_max(self.context, seqId), "commonTokens:", commonTokens.count)
         }
-        var batch = llama_batch_init(512, 0, 1)
-        defer { llama_batch_free(batch) }
+        self.batch.n_tokens = 0
         let n_ctx = llama_n_ctx(context)
         let n_kv_req = tokens.count + (Int(n_len) - tokens.count)
         if n_kv_req > n_ctx {
             debug("error: n_kv_req > n_ctx, the required KV cache size is not big enough")
         }
         for i in tokens.indices.dropFirst(prefixCacheCount) {
-            llama_batch_add(&batch, tokens[i], Int32(i), [seqId], logits: logits_start_index <= i)
+            llama_batch_add(&self.batch, tokens[i], Int32(i), [seqId], logits: logits_start_index <= i)
         }
         // 評価
-        if llama_decode(context, batch) != 0 {
+        if llama_decode(context, self.batch) != 0 {
             debug("llama_decode() failed")
             return nil
         }
@@ -163,16 +299,38 @@ final class ZenzContext {
         return llama_get_logits(context)
     }
 
-    func previousEvaluationPromptTokens() -> [llama_token] {
-        self.prevPromptBySeq[evalSeqId] ?? []
+    func previousEvaluationPrompt() -> String {
+        self.prevPromptBySeq[evalSeqId] ?? ""
     }
 
-    func setPreviousEvaluationPromptTokens(_ tokens: [llama_token]) {
-        self.prevPromptBySeq[evalSeqId] = tokens
+    func setPreviousEvaluationPrompt(_ prompt: String) {
+        self.prevPromptBySeq[evalSeqId] = prompt
+    }
+
+    func cachedEvaluation(for key: ZenzEvaluationCacheKey) -> CandidateEvaluationResult? {
+        self.sharedModel.evaluationCache.value(for: key)
+    }
+
+    func cacheEvaluation(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
+        self.sharedModel.evaluationCache.insert(result, for: key)
     }
 
     func normalizeForModel(_ text: String) -> String {
         self.preprocessText(text: text)
+    }
+
+    func encodeEvaluationPrompt(_ prompt: String) -> [llama_token] {
+        if let cached = self.evaluationPromptTokenCache, cached.prompt == prompt {
+            return cached.tokens
+        }
+        if let cached = self.sharedModel.evaluationPromptTokenCache.object(forKey: prompt as NSString) {
+            self.evaluationPromptTokenCache = (prompt, cached.tokens)
+            return cached.tokens
+        }
+        let tokens = self.encode(prompt, addBOS: true, addEOS: false)
+        self.evaluationPromptTokenCache = (prompt, tokens)
+        self.sharedModel.evaluationPromptTokenCache.setObject(ZenzTokenArrayBox(tokens), forKey: prompt as NSString)
+        return tokens
     }
 
     func encode(_ text: String, addBOS: Bool, addEOS: Bool = false) -> [llama_token] {
@@ -192,11 +350,11 @@ final class ZenzContext {
     }
 
     var vocabSize: Int {
-        Int(llama_vocab_n_tokens(vocab))
+        Int(llama_vocab_n_tokens(self.sharedModel.vocab))
     }
 
     var eosToken: llama_token {
-        llama_vocab_eos(vocab)
+        llama_vocab_eos(self.sharedModel.vocab)
     }
 
     func decodeTokens(_ tokens: [llama_token]) -> String {
@@ -225,15 +383,15 @@ final class ZenzContext {
         let utf8Count = text.utf8.count
         let n_tokens = utf8Count + (add_bos ? 1 : 0)
         let tokens = UnsafeMutablePointer<llama_token>.allocate(capacity: n_tokens)
-        let tokenCount = llama_tokenize(vocab, text, Int32(utf8Count), tokens, Int32(n_tokens), add_bos, false)
+        let tokenCount = llama_tokenize(self.sharedModel.vocab, text, Int32(utf8Count), tokens, Int32(n_tokens), add_bos, false)
         var swiftTokens: [llama_token] = if tokenCount < 0 {
-            [llama_vocab_bos(vocab)]
+            [llama_vocab_bos(self.sharedModel.vocab)]
         } else {
             (0..<tokenCount).map {tokens[Int($0)]}
         }
         tokens.deallocate()
         if add_eos {
-            swiftTokens.append(llama_vocab_eos(vocab))
+            swiftTokens.append(llama_vocab_eos(self.sharedModel.vocab))
         }
         return swiftTokens
     }
@@ -245,7 +403,7 @@ final class ZenzContext {
         defer {
             result.deallocate()
         }
-        let nTokens = llama_token_to_piece(vocab, token, result, 8, 0, false)
+        let nTokens = llama_token_to_piece(self.sharedModel.vocab, token, result, 8, 0, false)
 
         if nTokens < 0 {
             let newResult = UnsafeMutablePointer<Int8>.allocate(capacity: Int(-nTokens))
@@ -253,7 +411,7 @@ final class ZenzContext {
             defer {
                 newResult.deallocate()
             }
-            let nNewTokens = llama_token_to_piece(vocab, token, newResult, Int32(-nTokens), 0, false)
+            let nNewTokens = llama_token_to_piece(self.sharedModel.vocab, token, newResult, Int32(-nTokens), 0, false)
             let bufferPointer: UnsafeBufferPointer<Int8> = UnsafeBufferPointer(start: newResult, count: Int(nNewTokens))
             return Array(bufferPointer)
         } else {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -14,6 +14,7 @@ package struct llama_context_params {
     package var n_threads: Int32
     package var n_threads_batch: Int32
     package var n_batch: Int
+    package var flash_attn: Bool
 }
 package func llama_context_default_params() -> llama_context_params { unimplemented() }
 

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/LOUDS.swift
@@ -16,10 +16,11 @@ package struct LOUDS: Sendable {
 
     private let bits: [Unit]
     /// indexを並べてflattenしたArray。
+    /// LOUDS形式が4GB未満を前提としているため、64-bit環境でも`UInt32`で表現できる。
     ///  - seealso: flatChar2nodeIndicesIndex
-    private let flatChar2nodeIndices: [Int]
+    private let flatChar2nodeIndices: [UInt32]
     /// 256個の値を入れるArray。`flatChar2nodeIndices[flatChar2nodeIndicesIndex[char - 1] ..< flatChar2nodeIndicesIndex[char]]`が`nodeIndices`になる
-    private let flatChar2nodeIndicesIndex: [Int]
+    private let flatChar2nodeIndicesIndex: [UInt32]
     /// 0の数（1の数ではない）
     ///
     /// LOUDSのサイズが4GBまでは`UInt32`で十分
@@ -43,18 +44,18 @@ package struct LOUDS: Sendable {
         // すでに開始位置はflatChar2nodeIndicesIndexで分かるので、もう一度countsを構築しながら適切な場所にindexを入れていく
         var counts = [Int](repeating: 0, count: 256)
         self.flatChar2nodeIndices = counts.withUnsafeMutableBufferPointer { countsBuffer in
-            var flatChar2nodeIndices = [Int](repeating: 0, count: nodeIndex2ID.count)
+            var flatChar2nodeIndices = [UInt32](repeating: 0, count: nodeIndex2ID.count)
             for (i, value) in zip(nodeIndex2ID.indices, nodeIndex2ID) {
                 if value == .zero {
-                    flatChar2nodeIndices[countsBuffer[Int(value)]] = i
+                    flatChar2nodeIndices[countsBuffer[Int(value)]] = UInt32(i)
                 } else {
-                    flatChar2nodeIndices[flatChar2nodeIndicesIndex[Int(value) - 1] + countsBuffer[Int(value)]] = i
+                    flatChar2nodeIndices[flatChar2nodeIndicesIndex[Int(value) - 1] + countsBuffer[Int(value)]] = UInt32(i)
                 }
                 countsBuffer[Int(value)] += 1
             }
             return flatChar2nodeIndices
         }
-        self.flatChar2nodeIndicesIndex = flatChar2nodeIndicesIndex
+        self.flatChar2nodeIndicesIndex = flatChar2nodeIndicesIndex.map(UInt32.init)
 
         var rankLarge: [UInt32] = .init(repeating: 0, count: bytes.count + 1)
         rankLarge.withUnsafeMutableBufferPointer { buffer in
@@ -127,24 +128,28 @@ package struct LOUDS: Sendable {
     @inlinable func searchCharNodeIndex(from parentNodeIndex: Int, char: UInt8) -> Int? {
         // char2nodeIndicesには単調増加性があるので二分探索が成立する
         let childNodeIndices = self.childNodeIndices(from: parentNodeIndex)
-        let nodeIndices: ArraySlice<Int> = if char == .zero {
-            self.flatChar2nodeIndices[0 ..< self.flatChar2nodeIndicesIndex[Int(char)]]
+        let nodeIndices: ArraySlice<UInt32> = if char == .zero {
+            self.flatChar2nodeIndices[0 ..< Int(self.flatChar2nodeIndicesIndex[Int(char)])]
         } else {
-            self.flatChar2nodeIndices[self.flatChar2nodeIndicesIndex[Int(char - 1)] ..< self.flatChar2nodeIndicesIndex[Int(char)]]
+            self.flatChar2nodeIndices[
+                Int(self.flatChar2nodeIndicesIndex[Int(char - 1)]) ..< Int(self.flatChar2nodeIndicesIndex[Int(char)])
+            ]
         }
+        let childStart = UInt32(childNodeIndices.startIndex)
+        let childEnd = UInt32(childNodeIndices.endIndex)
 
         var left = nodeIndices.startIndex
         var right = nodeIndices.endIndex
         while left < right {
             let mid = (left + right) >> 1
-            if childNodeIndices.startIndex <= nodeIndices[mid] {
+            if childStart <= nodeIndices[mid] {
                 right = mid
             } else {
                 left = mid + 1
             }
         }
-        if left < nodeIndices.endIndex && childNodeIndices.contains(nodeIndices[left]) {
-            return nodeIndices[left]
+        if left < nodeIndices.endIndex && childStart <= nodeIndices[left] && nodeIndices[left] < childEnd {
+            return Int(nodeIndices[left])
         } else {
             return nil
         }

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -155,4 +155,59 @@ final class ZenzPromptBuilderTests: XCTestCase {
 
         XCTAssertEqual(constraint, Kana2Kanji.PrefixConstraint(Array("橋".utf8), hasEOS: true, ignoreMemoryAndUserDictionary: true))
     }
+
+    func testZenzEvaluationCacheEvictsLeastRecentlyUsedEntry() {
+        let cache = ZenzEvaluationCache(capacity: 2)
+        func key(_ prompt: String) -> ZenzEvaluationCacheKey {
+            ZenzEvaluationCacheKey(
+                prompt: prompt,
+                candidateTextForEvaluation: "候補",
+                originalCandidateText: "候補",
+                prefixConstraint: .init([]),
+                requestRichCandidates: false,
+                reusesAddressedPrefix: false,
+                candidateSegments: [.init(word: "候補", ruby: "コウホ", isLearned: false)]
+            )
+        }
+        let first = key("first")
+        let second = key("second")
+        let third = key("third")
+
+        cache.insert(.wholeResult("first"), for: first)
+        cache.insert(.wholeResult("second"), for: second)
+        XCTAssertEqual(cache.value(for: first), .wholeResult("first"))
+
+        cache.insert(.wholeResult("third"), for: third)
+
+        XCTAssertNil(cache.value(for: second))
+        XCTAssertEqual(cache.value(for: first), .wholeResult("first"))
+        XCTAssertEqual(cache.value(for: third), .wholeResult("third"))
+    }
+
+    func testZenzInferenceThreadCountUsesPerformanceClusterOnDarwin() {
+        XCTAssertEqual(
+            ZenzContext.selectInferenceThreadCount(
+                activeProcessorCount: 10,
+                performanceCoreCount: 6
+            ),
+            6
+        )
+    }
+
+    func testZenzInferenceThreadCountFallsBackWhenPerformanceClusterIsUnavailable() {
+        XCTAssertEqual(
+            ZenzContext.selectInferenceThreadCount(
+                activeProcessorCount: 8,
+                performanceCoreCount: nil
+            ),
+            6
+        )
+        XCTAssertEqual(
+            ZenzContext.selectInferenceThreadCount(
+                activeProcessorCount: 2,
+                performanceCoreCount: nil
+            ),
+            2
+        )
+    }
 }

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -4,6 +4,37 @@ import XCTest
 
 #if Zenzai || ZenzaiCPU
 final class ZenzaiTests: XCTestCase {
+    private func measuredRequestCandidates(
+        _ converter: KanaKanjiConverter,
+        composingText: ComposingText,
+        options: ConvertRequestOptions,
+        latencies: inout [Double]?
+    ) -> ConversionResult {
+        guard latencies != nil else {
+            return converter.requestCandidates(composingText, options: options)
+        }
+        let start = ProcessInfo.processInfo.systemUptime
+        let result = converter.requestCandidates(composingText, options: options)
+        latencies?.append((ProcessInfo.processInfo.systemUptime - start) * 1_000)
+        return result
+    }
+
+    private func reportLatencies(_ latencies: [Double]?, label: String) {
+        guard let latencies, !latencies.isEmpty else {
+            return
+        }
+        let sorted = latencies.sorted()
+        let average = sorted.reduce(0, +) / Double(sorted.count)
+        let p90Index = min(sorted.count - 1, Int(ceil(Double(sorted.count) * 0.9)) - 1)
+        print(
+            "[ZenzaiLatency] \(label)"
+                + " count=\(sorted.count)"
+                + " averageMs=\(average)"
+                + " p90Ms=\(sorted[p90Index])"
+                + " maxMs=\(sorted[sorted.count - 1])"
+        )
+    }
+
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: KanaKanjiConverterModule.InputStyle) {
         for char in sequence {
             composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
@@ -14,7 +45,6 @@ final class ZenzaiTests: XCTestCase {
         inferenceLimit: Int = Int.max,
         leftSideContext: String? = nil
     ) -> ConvertRequestOptions {
-        print("You need to install azooKeyMac.app to run this test.")
         return .init(
             N_best: 10,
             requireJapanesePrediction: .disabled,
@@ -83,13 +113,22 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
+        defer {
+            self.reportLatencies(latencies, label: "Direct")
+        }
         for inferenceLimit in [1, 2, 3, 5, .max] {
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "このぶんしょうはかんじへんかんがせいかくということでわだいのにほんごにゅうりょくしすてむをつかってうちこんでいます"
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .direct)
-                let results = converter.requestCandidates(c, options: requestOptions(inferenceLimit: inferenceLimit))
+                let results = self.measuredRequestCandidates(
+                    converter,
+                    composingText: c,
+                    options: requestOptions(inferenceLimit: inferenceLimit),
+                    latencies: &latencies
+                )
                 if c.input.count == text.count {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
@@ -101,13 +140,22 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion_Roman2Kana() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
+        defer {
+            self.reportLatencies(latencies, label: "Roman2Kana")
+        }
         for inferenceLimit in [1, 2, 3, 5, .max] {
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "konobunshouhakanjihenkangaseikakutoiukotodewadainonihongonyuuryokusisutemuwotukatteutikondeimasu"
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .roman2kana)
-                let results = converter.requestCandidates(c, options: requestOptions(inferenceLimit: inferenceLimit))
+                let results = self.measuredRequestCandidates(
+                    converter,
+                    composingText: c,
+                    options: requestOptions(inferenceLimit: inferenceLimit),
+                    latencies: &latencies
+                )
                 if c.input.count == text.count {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
@@ -119,13 +167,22 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion_AZIK() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
+        defer {
+            self.reportLatencies(latencies, label: "AZIK")
+        }
         for inferenceLimit in [1, 2, 3, 5, .max] {
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "konobjxphakzzihdkzgasskakutoiuktdewadqnonihlgonyhryokusisutemuwotuka；teutikldwms"
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .mapped(id: .defaultAZIK))
-                let results = converter.requestCandidates(c, options: requestOptions(inferenceLimit: inferenceLimit))
+                let results = self.measuredRequestCandidates(
+                    converter,
+                    composingText: c,
+                    options: requestOptions(inferenceLimit: inferenceLimit),
+                    latencies: &latencies
+                )
                 if c.input.count == text.count {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }


### PR DESCRIPTION
## 結果

- **Zenzai CPU推論の主要4ケース（Full / Direct incremental / Roman2Kana incremental / AZIK incremental）を約3倍高速化**
- N-best経路の共有により、長文incremental変換のpeak memory footprintを3.82 MiB（7.0%）削減
- LOUDSのUInt32化により、さらに約1.65 MiB削減し、通常のかな漢字変換も約4%高速化

## 概要

Zenzai CPU推論と通常のかな漢字変換について、incremental入力時の推論コストとピークメモリを削減します。

## 変更内容

- Darwin（macOS/iOS）のCPUトポロジーを取得し、最高性能クラスタの物理コア数から推論スレッド数を自動決定
- ZenzaiCPUでCPUデバイスのみを明示的に利用
- llama.cppバックエンドと読み取り専用モデルを同一プロセス内で共有
- llama batchを再利用し、flash attentionを有効化
- 同一プロンプトのトークン列を再利用
- 同一プロンプト・候補・制約に対するモデル評価結果を256件LRUで再利用
  - personalization中はキャッシュしない
  - エラー結果はキャッシュしない
- LOUDSのノードインデックスを64-bit `Int`から`UInt32`へ縮小
- N-best経路間で辞書要素と入力範囲を共有
- Direct / Roman2Kana / AZIKのincrementalテストに任意のレイテンシ出力を追加

## 背景

incremental入力では、入力の更新ごとに同一候補や同一プロンプトが再評価されます。また、N-best経路ごとに同一の辞書要素と入力範囲を複製していたため、長文入力では経路保持のメモリが大きくなっていました。

このPRではモデル評価の結果と不変データだけを共有し、KV cache、経路スコア、前ノードなどの可変・経路固有状態は従来どおり個別に保持します。入力範囲が更新された場合は共有payloadを無効化します。

## 計測結果

M2 Pro / release:

- Zenzai CPU推論: `testFullConversion` / `testGradualConversion` / `testGradualConversion_Roman2Kana` / `testGradualConversion_AZIK` の主要4ケースで約3倍高速化
- N-best payload共有（`testGradualConversion`、同条件5回平均）:
  - peak memory footprint: 57.32 MiB → 53.32 MiB（-3.82 MiB、-7.0%）
  - 実行時間: 0.625秒 → 0.624秒（実質同等）
- LOUDSのUInt32化: 長文Direct incrementalケースで約1.65 MiB削減、約4%高速化

## 検証

- `swift test -c release --traits ZenzaiCPU`
  - 180 tests passed
- `xcrun swift build -c release --triple arm64-apple-ios16.0 --sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk --traits ZenzaiCPU`
  - build succeeded
  - 既存のllama frameworkがiOS 16.4向けである旨のリンカ警告のみ