### PR TITLE
perf: further optimize incremental Zenzai CPU inference

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,9 +144,8 @@ let llamaCppTarget: Target = .systemLibrary(name: "llama.cpp")
 #else
 let llamaCppTarget: Target = .binaryTarget(
     name: "llama.cpp",
-    url: "https://github.com/azooKey/llama.cpp/releases/download/b4846/signed-llama.xcframework.zip",
-    // this can be computed `swift package compute-checksum llama-b4844-xcframework.zip`
-    checksum: "db3b13169df8870375f212e6ac21194225f1c85f7911d595ab64c8c790068e0a"
+    url: "https://github.com/azooKey/llama.cpp/releases/download/b9637-azookey.1/signed-llama-b9637-azookey.1.xcframework.zip",
+    checksum: "6176b3a6f7cbeca993644ca21d4b1c46ddaa59b98109376b7d32acef8e226a13"
 )
 #endif
 targets.append(llamaCppTarget)
@@ -165,7 +164,7 @@ targets.append(
 
 let package = Package(
     name: "AzooKeyKanaKanjiConverter",
-    platforms: [.iOS(.v16), .macOS(.v13)],
+    platforms: [.iOS(.v17), .macOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -5,41 +5,22 @@ import SwiftUtils
 extension Kana2Kanji {
     // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
     private func computeMatchedAndTotalLength(prev: RegisteredNode?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
-        // collect words from prev chain in forward order
-        var words: [String] = []
-        var p = prev
-        while let node = p {
-            if !node.data.word.isEmpty {
-                words.append(node.data.word)
-            }
-            p = node.prev
-        }
-        words.reverse()
-        words.append(currentWord)
+        let previousTotal = prev.map { Int($0.candidateUTF8Count) } ?? 0
+        var matched = prev.map { Int($0.constraintMatchedUTF8Count) } ?? 0
+        let total = previousTotal + currentWord.utf8.count
 
-        // total = sum of utf8 counts (cheap per word)
-        let total = words.reduce(0) { $0 + $1.utf8.count }
-
-        // matched = compare up to first mismatch or until constraint end
-        var ci = 0
-        if !constraintBytes.isEmpty {
-            outer: for w in words {
-                if ci >= constraintBytes.count {
-                    break
-                }
-                for b in w.utf8 {
-                    if ci >= constraintBytes.count {
-                        break outer
-                    }
-                    if b != constraintBytes[ci] {
-                        break outer
-                    }
-                    ci += 1
-                }
-            }
+        // 直前までに不一致がなければ、今回追加する単語だけを照合する。
+        // RegisteredNode生成時に累積値を保持するため、経路全体の再走査は不要。
+        guard matched == min(previousTotal, constraintBytes.count) else {
+            return (matched, total)
         }
-        // このprevのutf8カウントはtotalで、そのうちconstraintBytesと一致する部分がci
-        return (matched: ci, total: total)
+        for byte in currentWord.utf8 {
+            guard matched < constraintBytes.count, byte == constraintBytes[matched] else {
+                break
+            }
+            matched += 1
+        }
+        return (matched, total)
     }
 
     // Extend match with next word starting from current matched index
@@ -125,6 +106,96 @@ extension Kana2Kanji {
                 if node.prevs.isEmpty {
                     continue
                 }
+                if N_best == 1, let previous = node.prevs.first {
+                    let wValue = node.data.value()
+                    let value = previous.totalValue + wValue + (
+                        isHead
+                            ? self.dicdataStore.getCCValue(previous.data.rcid, node.data.lcid)
+                            : 0
+                    )
+                    let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
+                    let constraintBytes = constraint.constraint
+                    let matchState = self.computeMatchedAndTotalLength(
+                        prev: previous,
+                        currentWord: node.data.word,
+                        constraintBytes: constraintBytes
+                    )
+                    let constraintLength = constraintBytes.count
+
+                    if nextIndex.surfaceIndex == surfaceCount {
+                        if !constraint.ignoreMemoryAndUserDictionary,
+                           node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            let condition = if constraint.hasEOS {
+                                matchState.matched == constraintLength
+                                    && matchState.total == constraintLength
+                            } else {
+                                matchState.matched == constraintLength
+                            }
+                            guard condition else {
+                                continue
+                            }
+                        }
+                        let newNode = node.getRegisteredNode(
+                            0,
+                            value: value,
+                            constraintState: matchState
+                        )
+                        if let current = result.prevs.first {
+                            if newNode.totalValue > current.totalValue {
+                                result.prevs[0] = newNode
+                            }
+                        } else {
+                            result.prevs.append(newNode)
+                        }
+                        continue
+                    }
+
+                    let ccLatter = self.dicdataStore.getCCLatter(node.data.rcid)
+                    for nextNode in lattice[index: nextIndex] {
+                        let newValue = value + ccLatter.get(nextNode.data.lcid)
+                        if let current = nextNode.prevs.first,
+                           current.totalValue >= newValue {
+                            continue
+                        }
+                        if !constraint.ignoreMemoryAndUserDictionary,
+                           nextNode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            guard matchState.matched
+                                == min(matchState.total, constraintLength) else {
+                                continue
+                            }
+                            let nextLength = nextNode.data.word.utf8.count
+                            let (matched, mismatch) = self.extendMatched(
+                                matched: matchState.matched,
+                                nextWord: nextNode.data.word,
+                                constraintBytes: constraintBytes
+                            )
+                            if mismatch {
+                                continue
+                            }
+                            let newTotal = matchState.total + nextLength
+                            let isCompatible = if constraint.hasEOS {
+                                matched == newTotal && newTotal < constraintLength
+                            } else {
+                                matched == constraintLength
+                                    || (newTotal <= constraintLength && matched == newTotal)
+                            }
+                            guard isCompatible else {
+                                continue
+                            }
+                        }
+                        let newNode = node.getRegisteredNode(
+                            0,
+                            value: newValue,
+                            constraintState: matchState
+                        )
+                        if nextNode.prevs.isEmpty {
+                            nextNode.prevs.append(newNode)
+                        } else {
+                            nextNode.prevs[0] = newNode
+                        }
+                    }
+                    continue
+                }
                 // 生起確率を取得する。
                 let wValue: PValue = node.data.value()
                 if isHead {
@@ -158,8 +229,22 @@ extension Kana2Kanji {
                                 continue
                             }
                         }
-                        let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
-                        result.prevs.append(newnode)
+                        let newnode: RegisteredNode = node.getRegisteredNode(
+                            index,
+                            value: node.values[index],
+                            constraintState: mtPerPrev[index]
+                        )
+                        if N_best == 1 {
+                            if let current = result.prevs.first {
+                                if newnode.totalValue > current.totalValue {
+                                    result.prevs[0] = newnode
+                                }
+                            } else {
+                                result.prevs.append(newnode)
+                            }
+                        } else {
+                            result.prevs.append(newnode)
+                        }
                     }
                 } else {
                     // Precompute matched/total lengths per prev for (prev + current word)
@@ -214,7 +299,11 @@ extension Kana2Kanji {
                             if nextnode.prevs.count >= N_best {
                                 nextnode.prevs.removeLast()
                             }
-                            let newnode: RegisteredNode = node.getRegisteredNode(index, value: newValue)
+                            let newnode: RegisteredNode = node.getRegisteredNode(
+                                index,
+                                value: newValue,
+                                constraintState: mtPerPrev[index]
+                            )
                             // removeしてからinsertした方が速い (insertはO(N)なので)
                             nextnode.prevs.insert(newnode, at: lastindex)
                         }
@@ -305,18 +394,41 @@ extension Kana2Kanji {
         // 逐次入力の場合：既存Latticeから共通部分を再利用し、新しい部分のみ辞書引き
         let cachedLattice = incrementalCacheInfo.lattice
 
-        // 共通部分のLatticeを取得（SuffixReplacementProcessing.swiftのprefixメソッドを想定）
-        var newLattice = cachedLattice.prefix(inputCount: commonInputCount, surfaceCount: commonSurfaceCount)
+        // 純粋なsuffix追加では既存Latticeの全ノードがそのまま有効なので、
+        // 各ノード配列のfilterと再構築を避ける。削除を伴う場合だけprefixを切り出す。
+        var newLattice = if commonInputCount == oldInput.count,
+                            commonSurfaceCount == oldSurface.count {
+            cachedLattice
+        } else {
+            cachedLattice.prefix(
+                inputCount: commonInputCount,
+                surfaceCount: commonSurfaceCount
+            )
+        }
         newLattice.resetNodeStates()
 
         // 新規部分に関わる辞書引き（既存部分から新規部分にまたがる単語も含む）
+        // lookupDicdata自体がmaxlengthより長い範囲を探索しないため、それより前から
+        // 始まるノードは新規suffixへ到達できない。
+        let earliestAffectedInputIndex = max(
+            0,
+            commonInputCount + 1 - self.dicdataStore.maxlength
+        )
+        let earliestAffectedSurfaceIndex = max(
+            0,
+            commonSurfaceCount + 1 - self.dicdataStore.maxlength
+        )
         let additionalRawNodes = latticeIndices.map { index in
-            let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex, max(commonInputCount, iIndex) < inputCount {
+            let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex,
+                                                                              iIndex >= earliestAffectedInputIndex,
+                                                                              max(commonInputCount, iIndex) < inputCount {
                 (iIndex, max(commonInputCount, iIndex) ..< inputCount)
             } else {
                 nil
             }
-            let surfaceRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let sIndex = index.surfaceIndex, max(commonSurfaceCount, sIndex) < surfaceCount {
+            let surfaceRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let sIndex = index.surfaceIndex,
+                                                                                sIndex >= earliestAffectedSurfaceIndex,
+                                                                                max(commonSurfaceCount, sIndex) < surfaceCount {
                 (sIndex, max(commonSurfaceCount, sIndex) ..< surfaceCount)
             } else {
                 nil

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
@@ -14,8 +14,23 @@ struct LatticeNodeArray: Sequence {
 
 struct LatticeDualIndexMap: Sendable {
     private var inputIndexToSurfaceIndexMap: [Int: Int]
+    private var surfaceIndexToInputIndexMap: [Int: Int]
+    private var isIdentity: Bool
+
     init(_ composingText: ComposingText) {
-        self.inputIndexToSurfaceIndexMap = composingText.inputIndexToSurfaceIndexMap()
+        if composingText.hasIdentityInputSurfaceIndexMapping {
+            self.inputIndexToSurfaceIndexMap = [:]
+            self.surfaceIndexToInputIndexMap = [:]
+            self.isIdentity = true
+            return
+        }
+        let inputToSurface = composingText.inputIndexToSurfaceIndexMap()
+        self.inputIndexToSurfaceIndexMap = inputToSurface
+        self.surfaceIndexToInputIndexMap = Dictionary(
+            inputToSurface.map { ($0.value, $0.key) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        self.isIdentity = false
     }
 
     enum DualIndex: Sendable, Equatable, Hashable {
@@ -43,7 +58,13 @@ struct LatticeDualIndexMap: Sendable {
     }
 
     func dualIndex(for latticeIndex: Lattice.LatticeIndex) -> DualIndex {
-        switch latticeIndex {
+        if self.isIdentity {
+            return switch latticeIndex {
+            case .input(let index), .surface(let index):
+                .bothIndex(inputIndex: index, surfaceIndex: index)
+            }
+        }
+        return switch latticeIndex {
         case .input(let iIndex):
             if let sIndex = self.inputIndexToSurfaceIndexMap[iIndex] {
                 .bothIndex(inputIndex: iIndex, surfaceIndex: sIndex)
@@ -51,7 +72,7 @@ struct LatticeDualIndexMap: Sendable {
                 .inputIndex(iIndex)
             }
         case .surface(let sIndex):
-            if let iIndex = self.inputIndexToSurfaceIndexMap.filter({ $0.value == sIndex}).first?.key {
+            if let iIndex = self.surfaceIndexToInputIndexMap[sIndex] {
                 .bothIndex(inputIndex: iIndex, surfaceIndex: sIndex)
             } else {
                 .surfaceIndex(sIndex)
@@ -60,6 +81,11 @@ struct LatticeDualIndexMap: Sendable {
     }
 
     func indices(inputCount: Int, surfaceCount: Int) -> [DualIndex] {
+        if self.isIdentity {
+            return (0 ..< min(inputCount, surfaceCount)).map {
+                .bothIndex(inputIndex: $0, surfaceIndex: $0)
+            }
+        }
         var indices: [DualIndex] = []
         var sIndexPointer = 0
         for i in 0 ..< inputCount {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
@@ -37,7 +37,11 @@ public final class LatticeNode {
 
     /// `LatticeNode`の持っている情報を反映した`RegisteredNode`を作成する
     /// `LatticeNode`は複数の過去のノードを持つことができるが、`RegisteredNode`は1つしか持たない。
-    func getRegisteredNode(_ index: Int, value: PValue) -> RegisteredNode {
+    func getRegisteredNode(
+        _ index: Int,
+        value: PValue,
+        constraintState: (matched: Int, total: Int)? = nil
+    ) -> RegisteredNode {
         let payload: RegisteredNodePayload
         if let registeredNodePayload {
             payload = registeredNodePayload
@@ -45,7 +49,12 @@ public final class LatticeNode {
             payload = RegisteredNodePayload(data: self.data, range: self.range)
             self.registeredNodePayload = payload
         }
-        return RegisteredNode(payload: payload, registered: self.prevs[index], totalValue: value)
+        return RegisteredNode(
+            payload: payload,
+            registered: self.prevs[index],
+            totalValue: value,
+            constraintState: constraintState
+        )
     }
 
     /// 再帰的にノードを遡り、`CandidateData`を構築する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
@@ -14,13 +14,19 @@ final class RegisteredNodePayload {
 /// `indirect enum`を用いて再帰的なノード構造を実現する。
 /// 辞書データと入力範囲は、同じLatticeNodeから派生したN-best経路間で共有する。
 indirect enum RegisteredNode {
-    case node(payload: RegisteredNodePayload, prev: RegisteredNode?, totalValue: PValue)
+    case node(
+        payload: RegisteredNodePayload,
+        prev: RegisteredNode?,
+        totalValue: PValue,
+        candidateUTF8Count: UInt16,
+        constraintMatchedUTF8Count: UInt16
+    )
 
     /// このノードが保持する辞書データ
     var data: DicdataElement {
         _read {
             switch self {
-            case .node(let payload, _, _):
+            case .node(let payload, _, _, _, _):
                 yield payload.data
             }
         }
@@ -30,7 +36,7 @@ indirect enum RegisteredNode {
     var prev: RegisteredNode? {
         _read {
             switch self {
-            case .node(_, let prev, _):
+            case .node(_, let prev, _, _, _):
                 yield prev
             }
         }
@@ -39,29 +45,59 @@ indirect enum RegisteredNode {
     /// 始点からこのノードまでのコスト
     var totalValue: PValue {
         switch self {
-        case .node(_, _, let totalValue):
+        case .node(_, _, let totalValue, _, _):
             return totalValue
+        }
+    }
+
+    var candidateUTF8Count: UInt16 {
+        switch self {
+        case .node(_, _, _, let candidateUTF8Count, _):
+            return candidateUTF8Count
+        }
+    }
+
+    var constraintMatchedUTF8Count: UInt16 {
+        switch self {
+        case .node(_, _, _, _, let constraintMatchedUTF8Count):
+            return constraintMatchedUTF8Count
         }
     }
 
     /// `composingText`の`input`で対応する範囲
     var range: Lattice.LatticeRange {
         switch self {
-        case .node(let payload, _, _):
+        case .node(let payload, _, _, _, _):
             return payload.range
         }
     }
 
     init(data: DicdataElement, registered: RegisteredNode?, totalValue: PValue, range: Lattice.LatticeRange) {
+        let candidateUTF8Count = (registered.map { Int($0.candidateUTF8Count) } ?? 0) + data.word.utf8.count
         self = .node(
             payload: RegisteredNodePayload(data: data, range: range),
             prev: registered,
-            totalValue: totalValue
+            totalValue: totalValue,
+            candidateUTF8Count: UInt16(clamping: candidateUTF8Count),
+            constraintMatchedUTF8Count: 0
         )
     }
 
-    init(payload: RegisteredNodePayload, registered: RegisteredNode?, totalValue: PValue) {
-        self = .node(payload: payload, prev: registered, totalValue: totalValue)
+    init(
+        payload: RegisteredNodePayload,
+        registered: RegisteredNode?,
+        totalValue: PValue,
+        constraintState: (matched: Int, total: Int)? = nil
+    ) {
+        let candidateUTF8Count = constraintState?.total
+            ?? ((registered.map { Int($0.candidateUTF8Count) } ?? 0) + payload.data.word.utf8.count)
+        self = .node(
+            payload: payload,
+            prev: registered,
+            totalValue: totalValue,
+            candidateUTF8Count: UInt16(clamping: candidateUTF8Count),
+            constraintMatchedUTF8Count: UInt16(clamping: constraintState?.matched ?? 0)
+        )
     }
 
     /// 始点ノードを生成する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -2,9 +2,43 @@ import EfficientNGram
 package import Foundation
 import SwiftUtils
 
+/// 同一モデルのnative contextをConverter間で共有する。
+///
+/// CPU推論を直列化することで、複数Converterが同時に18 MiBのKV cacheを保持する
+/// ことを避ける。context内のKV再利用は毎回完全なtoken prefixを照合するため、
+/// セッションを跨いでも推論結果には影響しない。
+private final class SharedZenzCache: @unchecked Sendable {
+    static let shared = SharedZenzCache()
+
+    private init() {
+        self.cache.countLimit = 1
+    }
+
+    func zenz(resourceURL: URL) throws -> Zenz {
+        try self.lock.withLock {
+            let key = resourceURL.absoluteString as NSString
+            if let cached = self.cache.object(forKey: key) {
+                return cached
+            }
+            let zenz = try Zenz(resourceURL: resourceURL)
+            self.cache.setObject(zenz, forKey: key)
+            return zenz
+        }
+    }
+
+    private let cache = NSCache<NSString, Zenz>()
+    private let lock = NSLock()
+}
+
 package final class Zenz {
     package var resourceURL: URL
     private var zenzContext: ZenzContext?
+    private let inferenceLock = NSLock()
+
+    package static func shared(resourceURL: URL) throws -> Zenz {
+        try SharedZenzCache.shared.zenz(resourceURL: resourceURL)
+    }
+
     init(resourceURL: URL) throws {
         self.resourceURL = resourceURL
         do {
@@ -26,7 +60,21 @@ package final class Zenz {
     }
 
     package func endSession() {
-        try? self.zenzContext?.resetContext()
+        // contextはモデル単位で共有される。各呼び出し時にtoken prefixを照合して
+        // 不一致範囲を除去するため、Converter単位のnative context再生成は不要。
+    }
+
+    func cachedResolvedConversion(
+        for key: ZenzResolvedConversionCacheKey
+    ) -> ZenzResolvedConversion? {
+        self.zenzContext?.cachedResolvedConversion(for: key)
+    }
+
+    func cacheResolvedConversion(
+        _ value: ZenzResolvedConversion,
+        for key: ZenzResolvedConversionCacheKey
+    ) {
+        self.zenzContext?.cacheResolvedConversion(value, for: key)
     }
 
     func candidateEvaluate(
@@ -35,25 +83,29 @@ package final class Zenz {
         candidates: [Candidate],
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
+        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
-        guard let zenzContext else {
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return .error
+            }
+            for candidate in candidates {
+                return ZenzCandidateEvaluator.evaluate(
+                    context: zenzContext,
+                    input: convertTarget.toKatakana(),
+                    inputCursorPosition: convertTargetCursorPosition,
+                    candidate: candidate,
+                    requestRichCandidates: requestRichCandidates,
+                    prefixConstraint: prefixConstraint,
+                    incrementalPrefixConstraint: incrementalPrefixConstraint,
+                    personalizationMode: personalizationMode,
+                    versionDependentConfig: versionDependentConfig
+                )
+            }
             return .error
         }
-        for candidate in candidates {
-            return ZenzCandidateEvaluator.evaluate(
-                context: zenzContext,
-                input: convertTarget.toKatakana(),
-                inputCursorPosition: convertTargetCursorPosition,
-                candidate: candidate,
-                requestRichCandidates: requestRichCandidates,
-                prefixConstraint: prefixConstraint,
-                personalizationMode: personalizationMode,
-                versionDependentConfig: versionDependentConfig
-            )
-        }
-        return .error
     }
 
     func predictNextInputText(
@@ -65,26 +117,34 @@ package final class Zenz {
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
         possibleNexts: [String] = []
     ) -> String {
-        guard let zenzContext else {
-            return ""
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return ""
+            }
+            return ZenzInputTextGenerator.generate(
+                context: zenzContext,
+                leftSideContext: leftSideContext,
+                composingText: composingText,
+                count: count,
+                minLength: minLength,
+                maxEntropy: maxEntropy,
+                versionDependentConfig: versionDependentConfig,
+                possibleNexts: possibleNexts
+            )
         }
-        return ZenzInputTextGenerator.generate(
-            context: zenzContext,
-            leftSideContext: leftSideContext,
-            composingText: composingText,
-            count: count,
-            minLength: minLength,
-            maxEntropy: maxEntropy,
-            versionDependentConfig: versionDependentConfig,
-            possibleNexts: possibleNexts
-        )
     }
 
     package func pureGreedyDecoding(pureInput: String, maxCount: Int = .max) -> String {
-        guard let zenzContext else {
-            return ""
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return ""
+            }
+            return ZenzPureGreedyDecoder.decode(
+                context: zenzContext,
+                leftSideContext: pureInput,
+                maxCount: maxCount
+            )
         }
-        return ZenzPureGreedyDecoder.decode(context: zenzContext, leftSideContext: pureInput, maxCount: maxCount)
     }
 
     func generateTypoCandidates(
@@ -94,16 +154,18 @@ package final class Zenz {
         experimentalConfig: ExperimentalTypoCorrectionConfig,
         cache: ZenzaiTypoGenerationCache
     ) -> [ZenzaiTypoCandidate] {
-        guard let zenzContext else {
-            return []
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return []
+            }
+            return ZenzaiTypoCandidateGenerator.generate(
+                context: zenzContext,
+                leftSideContext: leftSideContext,
+                composingText: composingText,
+                inputStyle: inputStyle,
+                experimentalConfig: experimentalConfig,
+                cache: cache
+            )
         }
-        return ZenzaiTypoCandidateGenerator.generate(
-            context: zenzContext,
-            leftSideContext: leftSideContext,
-            composingText: composingText,
-            inputStyle: inputStyle,
-            experimentalConfig: experimentalConfig,
-            cache: cache
-        )
     }
 }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -83,7 +83,6 @@ package final class Zenz {
         candidates: [Candidate],
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
-        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
@@ -99,7 +98,6 @@ package final class Zenz {
                     candidate: candidate,
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: prefixConstraint,
-                    incrementalPrefixConstraint: incrementalPrefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig
                 )

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -78,14 +78,6 @@ final class ZenzEvaluationCache: @unchecked Sendable {
 }
 
 struct ZenzCandidateEvaluator {
-    private struct IncrementalEvaluationProjection {
-        var stableCandidatePrefix: String
-        var input: String
-        var candidateText: String
-        var remainingConstraint: [UInt8]
-        var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
-    }
-
     static func evaluate(
         context: ZenzContext,
         input: String,
@@ -93,36 +85,25 @@ struct ZenzCandidateEvaluator {
         candidate: Candidate,
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
-        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
-        let projection = self.incrementalEvaluationProjection(
-            input: input,
-            inputCursorPosition: inputCursorPosition,
-            candidate: candidate,
-            requestRichCandidates: requestRichCandidates,
-            prefixConstraint: prefixConstraint,
-            incrementalPrefixConstraint: incrementalPrefixConstraint,
-            personalizationMode: personalizationMode,
-            versionDependentConfig: versionDependentConfig
-        )
         var userDictionaryPrompt = ""
         for item in candidate.data where item.metadata.contains(.isFromUserDictionary) {
             userDictionaryPrompt += "\(item.word)(\(item.ruby.toHiragana()))"
         }
         let prompt = ZenzPromptBuilder.candidateEvaluationPrompt(
-            input: projection.input,
+            input: input,
             inputCursorPosition: inputCursorPosition,
             userDictionaryPrompt: userDictionaryPrompt,
-            versionDependentConfig: projection.versionDependentConfig
+            versionDependentConfig: versionDependentConfig
         )
         let candidateTextForEvaluation = self.candidateTextForEvaluation(
-            candidateText: projection.candidateText,
-            input: projection.input,
+            candidateText: candidate.text,
+            input: input,
             inputCursorPosition: inputCursorPosition,
-            versionDependentConfig: projection.versionDependentConfig
+            versionDependentConfig: versionDependentConfig
         )
         let normalizedPrompt = context.normalizeForModel(prompt)
         let prevPrompt = context.previousEvaluationPrompt()
@@ -166,9 +147,9 @@ struct ZenzCandidateEvaluator {
         let addressedTokens: [llama_token]
         if reusesAddressedPrefix {
             var prefix = ""
-            for character in projection.candidateText {
+            for character in candidate.text {
                 let newPrefix = prefix + String(character)
-                if projection.remainingConstraint.hasPrefix(newPrefix.utf8) {
+                if prefixConstraint.constraint.hasPrefix(newPrefix.utf8) {
                     prefix = newPrefix
                 } else {
                     break
@@ -319,8 +300,7 @@ struct ZenzCandidateEvaluator {
                         }
                         let data = Data(cchars.map { UInt8(bitPattern: $0) })
                         let string = String(data: data, encoding: .utf8) ?? ""
-                        let wholeResult = projection.stableCandidatePrefix
-                            + String(string.dropFirst(normalizedPrompt.count))
+                        let wholeResult = String(string.dropFirst(normalizedPrompt.count))
                         return finish(.wholeResult(wholeResult))
                     } else {
                         let candidateTokenIndex = i - promptTokens.count
@@ -336,8 +316,7 @@ struct ZenzCandidateEvaluator {
                             } + context.tokenToPiece(token: maxItem.token)
                             return finish(
                                 .fixRequired(
-                                    prefixConstraint: projection.stableCandidatePrefix.utf8
-                                        + cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                                    prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
                                 )
                             )
                         }
@@ -352,8 +331,7 @@ struct ZenzCandidateEvaluator {
                         altTokens.insertIfPossible(
                             AlternativeHighProbToken(
                                 token: item.token,
-                                constraint: projection.stableCandidatePrefix.utf8
-                                    + prefix.map(UInt8.init)
+                                constraint: prefix.map(UInt8.init)
                                     + context.tokenToPiece(token: item.token).map(UInt8.init),
                                 probabilityRatioToMaxProb: expf(item.logit - maxItem.logit)
                             )
@@ -414,92 +392,6 @@ struct ZenzCandidateEvaluator {
                     .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
                 }
             )
-        )
-    }
-
-    /// 直前のリクエストまでにモデルが受理した文節を左文脈へ移し、
-    /// 今回追加された範囲だけを評価する。
-    ///
-    /// 同一リクエスト内で新しく得た制約には適用せず、一括変換の探索は従来どおり。
-    /// 学習・ユーザ辞書・リッチ候補・カーソル途中入力でも、評価範囲の変更が
-    /// 各機能の意味を変えうるため全文を評価する。
-    private static func incrementalEvaluationProjection(
-        input: String,
-        inputCursorPosition: Int?,
-        candidate: Candidate,
-        requestRichCandidates: Bool,
-        prefixConstraint: Kana2Kanji.PrefixConstraint,
-        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
-        personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
-        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
-    ) -> IncrementalEvaluationProjection {
-        let unchanged = IncrementalEvaluationProjection(
-            stableCandidatePrefix: "",
-            input: input,
-            candidateText: candidate.text,
-            remainingConstraint: prefixConstraint.constraint,
-            versionDependentConfig: versionDependentConfig
-        )
-        guard inputCursorPosition == nil,
-              !requestRichCandidates,
-              personalizationMode == nil,
-              let incrementalPrefixConstraint,
-              !incrementalPrefixConstraint.constraint.isEmpty,
-              candidate.data.allSatisfy({
-                  $0.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary])
-              }) else {
-            return unchanged
-        }
-
-        var remainingInput = input[...]
-        var remainingConstraint = incrementalPrefixConstraint.constraint[...]
-        var matchedSegments: [(word: String, ruby: String)] = []
-        for data in candidate.data where !data.word.isEmpty {
-            let ruby = data.ruby.toKatakana()
-            let wordBytes = Array(data.word.utf8)
-            guard remainingInput.hasPrefix(ruby),
-                  remainingConstraint.hasPrefix(wordBytes) else {
-                break
-            }
-            matchedSegments.append((data.word, ruby))
-            remainingInput = remainingInput.dropFirst(ruby.count)
-            remainingConstraint = remainingConstraint.dropFirst(wordBytes.count)
-        }
-
-        // 直近の一致文節は、新しい入力によって再解釈できるよう評価対象に残す。
-        guard matchedSegments.count >= 2 else {
-            return unchanged
-        }
-        let stableSegments = matchedSegments.dropLast()
-        let stableCandidatePrefix = stableSegments.reduce(into: "") { $0 += $1.word }
-        let stableRubyPrefix = stableSegments.reduce(into: "") { $0 += $1.ruby }
-        guard candidate.text.hasPrefix(stableCandidatePrefix),
-              input.hasPrefix(stableRubyPrefix),
-              incrementalPrefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8),
-              prefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8) else {
-            return unchanged
-        }
-
-        let projectedInput = String(input.dropFirst(stableRubyPrefix.count))
-        let projectedCandidate = String(candidate.text.dropFirst(stableCandidatePrefix.count))
-        let projectedConstraint = Array(
-            prefixConstraint.constraint.dropFirst(stableCandidatePrefix.utf8.count)
-        )
-        let projectedConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
-        switch versionDependentConfig {
-        case .v2(var mode):
-            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
-            projectedConfig = .v2(mode)
-        case .v3(var mode):
-            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
-            projectedConfig = .v3(mode)
-        }
-        return IncrementalEvaluationProjection(
-            stableCandidatePrefix: stableCandidatePrefix,
-            input: projectedInput,
-            candidateText: projectedCandidate,
-            remainingConstraint: projectedConstraint,
-            versionDependentConfig: projectedConfig
         )
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -78,6 +78,14 @@ final class ZenzEvaluationCache: @unchecked Sendable {
 }
 
 struct ZenzCandidateEvaluator {
+    private struct IncrementalEvaluationProjection {
+        var stableCandidatePrefix: String
+        var input: String
+        var candidateText: String
+        var remainingConstraint: [UInt8]
+        var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    }
+
     static func evaluate(
         context: ZenzContext,
         input: String,
@@ -85,25 +93,36 @@ struct ZenzCandidateEvaluator {
         candidate: Candidate,
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
+        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
+        let projection = self.incrementalEvaluationProjection(
+            input: input,
+            inputCursorPosition: inputCursorPosition,
+            candidate: candidate,
+            requestRichCandidates: requestRichCandidates,
+            prefixConstraint: prefixConstraint,
+            incrementalPrefixConstraint: incrementalPrefixConstraint,
+            personalizationMode: personalizationMode,
+            versionDependentConfig: versionDependentConfig
+        )
         var userDictionaryPrompt = ""
         for item in candidate.data where item.metadata.contains(.isFromUserDictionary) {
             userDictionaryPrompt += "\(item.word)(\(item.ruby.toHiragana()))"
         }
         let prompt = ZenzPromptBuilder.candidateEvaluationPrompt(
-            input: input,
+            input: projection.input,
             inputCursorPosition: inputCursorPosition,
             userDictionaryPrompt: userDictionaryPrompt,
-            versionDependentConfig: versionDependentConfig
+            versionDependentConfig: projection.versionDependentConfig
         )
         let candidateTextForEvaluation = self.candidateTextForEvaluation(
-            candidateText: candidate.text,
-            input: input,
+            candidateText: projection.candidateText,
+            input: projection.input,
             inputCursorPosition: inputCursorPosition,
-            versionDependentConfig: versionDependentConfig
+            versionDependentConfig: projection.versionDependentConfig
         )
         let normalizedPrompt = context.normalizeForModel(prompt)
         let prevPrompt = context.previousEvaluationPrompt()
@@ -147,9 +166,9 @@ struct ZenzCandidateEvaluator {
         let addressedTokens: [llama_token]
         if reusesAddressedPrefix {
             var prefix = ""
-            for character in candidate.text {
+            for character in projection.candidateText {
                 let newPrefix = prefix + String(character)
-                if prefixConstraint.constraint.hasPrefix(newPrefix.utf8) {
+                if projection.remainingConstraint.hasPrefix(newPrefix.utf8) {
                     prefix = newPrefix
                 } else {
                     break
@@ -162,20 +181,26 @@ struct ZenzCandidateEvaluator {
 
         let tokens = promptTokens + candidateTokens
         let startOffset = promptTokens.count - 1 + addressedTokens.count
-        guard let logits = context.evaluationLogits(tokens: tokens, startOffset: startOffset) else {
-            debug("logits unavailable")
-            return .error
-        }
         let n_vocab = Int(context.vocabSize)
-        let candidateLearnedTokens: [(isLearned: Bool, priority: Float)] = candidate.data.flatMap {
-            Array(repeating: ($0.metadata.contains(.isLearned), logf(self.learningPriority(data: $0))), count: context.encode($0.word, addBOS: false).count)
-        }
-        let candidateTokenMetadata = if candidateLearnedTokens.count >= candidateTokens.count {
-            Array(candidateLearnedTokens.prefix(candidateTokens.count))
+        let learnedTokenPriorities: [Float]?
+        if candidate.data.contains(where: { $0.metadata.contains(.isLearned) }) {
+            let candidateLearnedTokens = candidate.data.flatMap {
+                Array(
+                    repeating: $0.metadata.contains(.isLearned) ? logf(self.learningPriority(data: $0)) : 0,
+                    count: context.encode($0.word, addBOS: false).count
+                )
+            }
+            if candidateLearnedTokens.count >= candidateTokens.count {
+                learnedTokenPriorities = Array(candidateLearnedTokens.prefix(candidateTokens.count))
+            } else {
+                learnedTokenPriorities = candidateLearnedTokens + Array(
+                    repeating: 0,
+                    count: candidateTokens.count - candidateLearnedTokens.count
+                )
+            }
         } else {
-            candidateLearnedTokens + Array(repeating: (false, 0), count: candidateTokens.count - candidateLearnedTokens.count)
+            learnedTokenPriorities = nil
         }
-        let isLearnedToken: [(isLearned: Bool, priority: Float)] = Array(repeating: (false, 0), count: promptTokens.count) + candidateTokenMetadata
 
         var score: Float = 0
 
@@ -189,92 +214,198 @@ struct ZenzCandidateEvaluator {
             var probabilityRatioToMaxProb: Float
         }
 
-        struct TokenAndLogprob: Comparable {
-            static func < (lhs: TokenAndLogprob, rhs: TokenAndLogprob) -> Bool {
-                lhs.logprob < rhs.logprob
+        struct TokenAndLogit: Comparable {
+            static func < (lhs: TokenAndLogit, rhs: TokenAndLogit) -> Bool {
+                lhs.logit < rhs.logit
             }
             var token: llama_token
-            var logprob: Float
+            var logit: Float
         }
 
         var altTokens = FixedSizeHeap<AlternativeHighProbToken>(size: requestRichCandidates ? 5 : 0)
-        for (i, tokenID) in tokens.indexed().dropFirst(startOffset + 1) {
-            var sumexp: Float = 0
-            let startIndex = (i - 1 - startOffset) * Int(n_vocab)
-            let endIndex = (i - startOffset) * Int(n_vocab)
-            var tokenHeap = FixedSizeHeap<TokenAndLogprob>(size: requestRichCandidates ? 3 : 1)
-            for index in startIndex ..< endIndex {
-                sumexp += expf(logits[index])
-            }
-            let logsumexp = logf(sumexp)
+        func evaluateTokenRange(
+            _ range: Range<Int>,
+            logits: UnsafeMutablePointer<Float>,
+            logitsStartIndex: Int
+        ) -> CandidateEvaluationResult? {
+            for i in range {
+                let tokenID = tokens[i]
+                let startIndex = (i - 1 - logitsStartIndex) * n_vocab
+                let endIndex = startIndex + n_vocab
+                var tokenHeap = FixedSizeHeap<TokenAndLogit>(size: requestRichCandidates ? 3 : 0)
+                let maxItem: TokenAndLogit
 
-            if let (mode, baseLM, personalLM) = personalizationMode, mode.alpha > 0 {
-                let prefix = tokens[..<i].dropFirst(promptTokens.count).map(Int.init)
-                let baseProb: [Float]
-                let personalProb: [Float]
-                if !prefix.isEmpty {
-                    baseProb = baseLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
-                    personalProb = personalLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
-                } else {
-                    baseProb = Array(repeating: 0, count: Int(n_vocab))
-                    personalProb = baseProb
-                }
-                for (vocabIndex, (lpb, lpp)) in zip(0 ..< Int(n_vocab), zip(baseProb, personalProb)) {
-                    let logp = logits[startIndex + vocabIndex] - logsumexp
-                    let personalizedLogp = logp + mode.alpha * (lpp - lpb)
-                    tokenHeap.insertIfPossible(TokenAndLogprob(token: llama_token(vocabIndex), logprob: personalizedLogp))
-                }
-            } else {
-                for index in startIndex ..< endIndex {
-                    let logp = logits[index] - logsumexp
-                    tokenHeap.insertIfPossible(TokenAndLogprob(token: llama_token(index - startIndex), logprob: logp))
-                }
-            }
-
-            guard let maxItem = tokenHeap.max else {
-                debug("Max Item could not be found for unknown reason")
-                return .error
-            }
-            if maxItem.token != tokenID {
-                if maxItem.token == context.eosToken {
-                    let cchars: [CChar] = tokens[..<i].reduce(into: []) {
-                        $0.append(contentsOf: context.tokenToPiece(token: $1))
+                if let (mode, baseLM, personalLM) = personalizationMode, mode.alpha > 0 {
+                    let prefix = tokens[..<i].dropFirst(promptTokens.count).map(Int.init)
+                    let baseProb: [Float]
+                    let personalProb: [Float]
+                    if !prefix.isEmpty {
+                        baseProb = baseLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
+                        personalProb = personalLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
+                    } else {
+                        baseProb = Array(repeating: 0, count: n_vocab)
+                        personalProb = baseProb
                     }
-                    let data = Data(cchars.map { UInt8(bitPattern: $0) })
-                    let string = String(data: data, encoding: .utf8) ?? ""
-                    let wholeResult = String(string.dropFirst(normalizedPrompt.count))
-                    return finish(.wholeResult(wholeResult))
+                    if requestRichCandidates {
+                        for (vocabIndex, (lpb, lpp)) in zip(
+                            0 ..< n_vocab,
+                            zip(baseProb, personalProb)
+                        ) {
+                            let personalizedLogit = logits[startIndex + vocabIndex]
+                                + mode.alpha * (lpp - lpb)
+                            tokenHeap.insertIfPossible(
+                                TokenAndLogit(
+                                    token: llama_token(vocabIndex),
+                                    logit: personalizedLogit
+                                )
+                            )
+                        }
+                        guard let maximum = tokenHeap.max else {
+                            debug("Max Item could not be found for unknown reason")
+                            return .error
+                        }
+                        maxItem = maximum
+                    } else {
+                        var maximum = TokenAndLogit(
+                            token: 0,
+                            logit: logits[startIndex] + mode.alpha * (personalProb[0] - baseProb[0])
+                        )
+                        for vocabIndex in 1 ..< n_vocab {
+                            let personalizedLogit = logits[startIndex + vocabIndex]
+                                + mode.alpha * (personalProb[vocabIndex] - baseProb[vocabIndex])
+                            if personalizedLogit > maximum.logit {
+                                maximum = TokenAndLogit(
+                                    token: llama_token(vocabIndex),
+                                    logit: personalizedLogit
+                                )
+                            }
+                        }
+                        maxItem = maximum
+                    }
+                } else if requestRichCandidates {
+                    for index in startIndex ..< endIndex {
+                        tokenHeap.insertIfPossible(
+                            TokenAndLogit(
+                                token: llama_token(index - startIndex),
+                                logit: logits[index]
+                            )
+                        )
+                    }
+                    guard let maximum = tokenHeap.max else {
+                        debug("Max Item could not be found for unknown reason")
+                        return .error
+                    }
+                    maxItem = maximum
                 } else {
-                    let actualLogp = logits[startIndex + Int(tokenID)] - logsumexp
-                    let preferLearnedToken = isLearnedToken[i].isLearned && actualLogp + isLearnedToken[i].priority > maxItem.logprob
-                    if !preferLearnedToken {
+                    var maximumToken = 0
+                    var maximumLogit = logits[startIndex]
+                    for vocabIndex in 1 ..< n_vocab {
+                        let logit = logits[startIndex + vocabIndex]
+                        if logit > maximumLogit {
+                            maximumToken = vocabIndex
+                            maximumLogit = logit
+                        }
+                    }
+                    maxItem = TokenAndLogit(
+                        token: llama_token(maximumToken),
+                        logit: maximumLogit
+                    )
+                }
+
+                if maxItem.token != tokenID {
+                    if maxItem.token == context.eosToken {
                         let cchars = tokens[..<i].reduce(into: []) {
                             $0.append(contentsOf: context.tokenToPiece(token: $1))
-                        } + context.tokenToPiece(token: maxItem.token)
-                        return finish(
-                            .fixRequired(
-                                prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                        }
+                        let data = Data(cchars.map { UInt8(bitPattern: $0) })
+                        let string = String(data: data, encoding: .utf8) ?? ""
+                        let wholeResult = projection.stableCandidatePrefix
+                            + String(string.dropFirst(normalizedPrompt.count))
+                        return finish(.wholeResult(wholeResult))
+                    } else {
+                        let candidateTokenIndex = i - promptTokens.count
+                        let learnedPriority = learnedTokenPriorities.map {
+                            candidateTokenIndex < $0.count ? $0[candidateTokenIndex] : 0
+                        } ?? 0
+                        // softmaxの正規化項は両辺で相殺されるため、logitのまま比較できる。
+                        let preferLearnedToken = learnedPriority > 0
+                            && logits[startIndex + Int(tokenID)] + learnedPriority > maxItem.logit
+                        if !preferLearnedToken {
+                            let cchars = tokens[..<i].reduce(into: []) {
+                                $0.append(contentsOf: context.tokenToPiece(token: $1))
+                            } + context.tokenToPiece(token: maxItem.token)
+                            return finish(
+                                .fixRequired(
+                                    prefixConstraint: projection.stableCandidatePrefix.utf8
+                                        + cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                                )
+                            )
+                        }
+                    }
+                } else if requestRichCandidates {
+                    tokenHeap.removeMax()
+                    let prefix = tokens[..<i].reduce(into: []) {
+                        $0.append(contentsOf: context.tokenToPiece(token: $1))
+                    }.dropFirst(normalizedPrompt.utf8.count)
+
+                    for item in tokenHeap.unordered {
+                        altTokens.insertIfPossible(
+                            AlternativeHighProbToken(
+                                token: item.token,
+                                constraint: projection.stableCandidatePrefix.utf8
+                                    + prefix.map(UInt8.init)
+                                    + context.tokenToPiece(token: item.token).map(UInt8.init),
+                                probabilityRatioToMaxProb: expf(item.logit - maxItem.logit)
                             )
                         )
                     }
                 }
-            } else if !tokenHeap.isEmpty {
-                tokenHeap.removeMax()
-                let prefix = tokens[..<i].reduce(into: []) {
-                    $0.append(contentsOf: context.tokenToPiece(token: $1))
-                }.dropFirst(normalizedPrompt.utf8.count)
+                // この値は順位付けには使われない。正規化項の全語彙走査を避けるため、
+                // 等価な順位を持つ未正規化logitを蓄積する。
+                score += maxItem.logit
+            }
+            return nil
+        }
 
-                for item in tokenHeap.unordered {
-                    altTokens.insertIfPossible(
-                        AlternativeHighProbToken(
-                            token: item.token,
-                            constraint: prefix.map(UInt8.init) + context.tokenToPiece(token: item.token).map(UInt8.init),
-                            probabilityRatioToMaxProb: expf(item.logprob - maxItem.logprob)
-                        )
-                    )
+        let firstTokenIndex = startOffset + 1
+        if firstTokenIndex < tokens.endIndex {
+            // 修正要求は候補の冒頭で確定することが多い。最初の少数tokenだけを
+            // decodeして判定し、必要な場合に限って残りを一括decodeする。
+            let firstChunkEndIndex = min(tokens.endIndex, firstTokenIndex + 4)
+            let firstChunkTokens = Array(tokens[..<firstChunkEndIndex])
+            guard let logits = context.evaluationLogits(
+                tokens: firstChunkTokens,
+                startOffset: startOffset
+            ) else {
+                debug("logits unavailable")
+                return .error
+            }
+            if let result = evaluateTokenRange(
+                firstTokenIndex ..< firstChunkEndIndex,
+                logits: logits,
+                logitsStartIndex: startOffset
+            ) {
+                return result
+            }
+
+            if firstChunkEndIndex < tokens.endIndex {
+                // 境界直前のtokenをlogits付きで再計算し、続きの最初のtokenを評価する。
+                let continuationStartOffset = firstChunkEndIndex - 1
+                guard let logits = context.evaluationLogits(
+                    tokens: tokens,
+                    startOffset: continuationStartOffset
+                ) else {
+                    debug("logits unavailable")
+                    return .error
+                }
+                if let result = evaluateTokenRange(
+                    firstChunkEndIndex ..< tokens.endIndex,
+                    logits: logits,
+                    logitsStartIndex: continuationStartOffset
+                ) {
+                    return result
                 }
             }
-            score += maxItem.logprob
         }
         return finish(
             .pass(
@@ -283,6 +414,92 @@ struct ZenzCandidateEvaluator {
                     .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
                 }
             )
+        )
+    }
+
+    /// 直前のリクエストまでにモデルが受理した文節を左文脈へ移し、
+    /// 今回追加された範囲だけを評価する。
+    ///
+    /// 同一リクエスト内で新しく得た制約には適用せず、一括変換の探索は従来どおり。
+    /// 学習・ユーザ辞書・リッチ候補・カーソル途中入力でも、評価範囲の変更が
+    /// 各機能の意味を変えうるため全文を評価する。
+    private static func incrementalEvaluationProjection(
+        input: String,
+        inputCursorPosition: Int?,
+        candidate: Candidate,
+        requestRichCandidates: Bool,
+        prefixConstraint: Kana2Kanji.PrefixConstraint,
+        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
+        personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
+        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    ) -> IncrementalEvaluationProjection {
+        let unchanged = IncrementalEvaluationProjection(
+            stableCandidatePrefix: "",
+            input: input,
+            candidateText: candidate.text,
+            remainingConstraint: prefixConstraint.constraint,
+            versionDependentConfig: versionDependentConfig
+        )
+        guard inputCursorPosition == nil,
+              !requestRichCandidates,
+              personalizationMode == nil,
+              let incrementalPrefixConstraint,
+              !incrementalPrefixConstraint.constraint.isEmpty,
+              candidate.data.allSatisfy({
+                  $0.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary])
+              }) else {
+            return unchanged
+        }
+
+        var remainingInput = input[...]
+        var remainingConstraint = incrementalPrefixConstraint.constraint[...]
+        var matchedSegments: [(word: String, ruby: String)] = []
+        for data in candidate.data where !data.word.isEmpty {
+            let ruby = data.ruby.toKatakana()
+            let wordBytes = Array(data.word.utf8)
+            guard remainingInput.hasPrefix(ruby),
+                  remainingConstraint.hasPrefix(wordBytes) else {
+                break
+            }
+            matchedSegments.append((data.word, ruby))
+            remainingInput = remainingInput.dropFirst(ruby.count)
+            remainingConstraint = remainingConstraint.dropFirst(wordBytes.count)
+        }
+
+        // 直近の一致文節は、新しい入力によって再解釈できるよう評価対象に残す。
+        guard matchedSegments.count >= 2 else {
+            return unchanged
+        }
+        let stableSegments = matchedSegments.dropLast()
+        let stableCandidatePrefix = stableSegments.reduce(into: "") { $0 += $1.word }
+        let stableRubyPrefix = stableSegments.reduce(into: "") { $0 += $1.ruby }
+        guard candidate.text.hasPrefix(stableCandidatePrefix),
+              input.hasPrefix(stableRubyPrefix),
+              incrementalPrefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8),
+              prefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8) else {
+            return unchanged
+        }
+
+        let projectedInput = String(input.dropFirst(stableRubyPrefix.count))
+        let projectedCandidate = String(candidate.text.dropFirst(stableCandidatePrefix.count))
+        let projectedConstraint = Array(
+            prefixConstraint.constraint.dropFirst(stableCandidatePrefix.utf8.count)
+        )
+        let projectedConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+        switch versionDependentConfig {
+        case .v2(var mode):
+            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
+            projectedConfig = .v2(mode)
+        case .v3(var mode):
+            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
+            projectedConfig = .v3(mode)
+        }
+        return IncrementalEvaluationProjection(
+            stableCandidatePrefix: stableCandidatePrefix,
+            input: projectedInput,
+            candidateText: projectedCandidate,
+            remainingConstraint: projectedConstraint,
+            versionDependentConfig: projectedConfig
         )
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -347,42 +347,22 @@ struct ZenzCandidateEvaluator {
 
         let firstTokenIndex = startOffset + 1
         if firstTokenIndex < tokens.endIndex {
-            // 修正要求は候補の冒頭で確定することが多い。最初の少数tokenだけを
-            // decodeして判定し、必要な場合に限って残りを一括decodeする。
-            let firstChunkEndIndex = min(tokens.endIndex, firstTokenIndex + 4)
-            let firstChunkTokens = Array(tokens[..<firstChunkEndIndex])
+            // token i の判定に必要なのは token i - 1 のlogitsまでなので、
+            // 最終候補token自体はdecodeしない。
+            let evaluationTokens = Array(tokens.dropLast())
             guard let logits = context.evaluationLogits(
-                tokens: firstChunkTokens,
+                tokens: evaluationTokens,
                 startOffset: startOffset
             ) else {
                 debug("logits unavailable")
                 return .error
             }
             if let result = evaluateTokenRange(
-                firstTokenIndex ..< firstChunkEndIndex,
+                firstTokenIndex ..< tokens.endIndex,
                 logits: logits,
                 logitsStartIndex: startOffset
             ) {
                 return result
-            }
-
-            if firstChunkEndIndex < tokens.endIndex {
-                // 境界直前のtokenをlogits付きで再計算し、続きの最初のtokenを評価する。
-                let continuationStartOffset = firstChunkEndIndex - 1
-                guard let logits = context.evaluationLogits(
-                    tokens: tokens,
-                    startOffset: continuationStartOffset
-                ) else {
-                    debug("logits unavailable")
-                    return .error
-                }
-                if let result = evaluateTokenRange(
-                    firstChunkEndIndex ..< tokens.endIndex,
-                    logits: logits,
-                    logitsStartIndex: continuationStartOffset
-                ) {
-                    return result
-                }
             }
         }
         return finish(

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -143,6 +143,11 @@ private final class SharedZenzModel {
         ZenzBackend.initializeIfNeeded()
         var modelParams = llama_model_default_params()
         modelParams.use_mmap = true
+        #if ZenzaiCPU && os(iOS)
+        // b9637のCPU weight repackはモデルと同程度の追加bufferを常駐させる。
+        // iOSのメモリ制約を優先し、mmapされた元の量子化weightを直接利用する。
+        modelParams.use_extra_bufts = false
+        #endif
         #if ZenzaiCPU
         modelParams.n_gpu_layers = 0
         modelParams.split_mode = LLAMA_SPLIT_MODE_NONE

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -244,6 +244,8 @@ final class ZenzContext {
         ctx_params.n_ubatch = 64
         #endif
         ctx_params.flash_attn = true
+        // 推論時間は呼び出し側で計測する。llama.cpp内部の統計更新は不要。
+        ctx_params.no_perf = true
         return ctx_params
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -30,6 +30,11 @@ enum ZenzError: LocalizedError {
 /// コンテキストより先に解放される可能性があるプロセス終了時の明示解放は行わない。
 private enum ZenzBackend {
     private static let initialized: Void = {
+        #if ZenzaiCPU && canImport(Darwin)
+        // llama.cpp b9637ではbackend registry生成時にMetalも初期化される。
+        // CPU推論ではMetal shaderの初期ロードを避ける。
+        setenv("GGML_DISABLE_METAL", "1", 0)
+        #endif
         llama_backend_init()
     }()
 
@@ -237,13 +242,22 @@ final class ZenzContext {
         debug("Using \(n_threads) threads")
         var ctx_params = llama_context_default_params()
         ctx_params.n_ctx = 512
+        #if os(Linux) || os(Windows)
+        ctx_params.flash_attn = true
+        #else
+        // 評価用(0)と入力予測用(1)の2 sequenceを同一KV cacheで扱う。
+        ctx_params.n_seq_max = 2
+        // 両sequenceはpromptの大部分を共有する。512 tokenの総容量を分割せず、
+        // 従来と同じ容量のKV cacheとして共有する。
+        ctx_params.kv_unified = true
+        ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED
+        #endif
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
         #if Zenzai || ZenzaiCPU
         ctx_params.n_ubatch = 64
         #endif
-        ctx_params.flash_attn = true
         // 推論時間は呼び出し側で計測する。llama.cpp内部の統計更新は不要。
         ctx_params.no_perf = true
         return ctx_params
@@ -334,6 +348,9 @@ final class ZenzContext {
     }
 
     private func getLogits(tokens: [llama_token], logits_start_index: Int = 0, seqId: llama_seq_id = 0) -> UnsafeMutablePointer<Float>? {
+        #if !os(Linux) && !os(Windows)
+        let memory = llama_get_memory(self.context)
+        #endif
         let currentPrevInput = self.prevInputBySeq[seqId] ?? []
         var effectivePrevInput = currentPrevInput
 
@@ -351,8 +368,13 @@ final class ZenzContext {
             if otherPrefix > currentPrefix {
                 let copiedPrefixCount = min(otherPrefix, logits_start_index)
                 if copiedPrefixCount > 0 {
+                    #if os(Linux) || os(Windows)
                     llama_kv_cache_seq_rm(context, seqId, 0, -1)
                     llama_kv_cache_seq_cp(context, otherSeqId, seqId, 0, llama_pos(copiedPrefixCount))
+                    #else
+                    llama_memory_seq_rm(memory, seqId, 0, -1)
+                    llama_memory_seq_cp(memory, otherSeqId, seqId, 0, llama_pos(copiedPrefixCount))
+                    #endif
                     effectivePrevInput = otherPrevInput
                 }
             }
@@ -361,14 +383,23 @@ final class ZenzContext {
         // Manage KV cache: remove entries that differ from previous input
         let prefixCacheCount: Int
         do {
+            #if os(Linux) || os(Windows)
             let pos_max = llama_kv_cache_seq_pos_max(self.context, seqId)
+            #else
+            let pos_max = llama_memory_seq_pos_max(memory, seqId)
+            #endif
             debug("pos max:", pos_max, "prevInput count:", effectivePrevInput.count, "tokens count:", tokens.count)
             let commonTokens = effectivePrevInput.commonPrefix(with: tokens)
             // Remove KV cache from position commonTokens.count onwards to recompute divergent part
             // removed range: [llama_pos(commonTokens.count), inf)
             prefixCacheCount = min(commonTokens.count, logits_start_index)
+            #if os(Linux) || os(Windows)
             llama_kv_cache_seq_rm(context, seqId, llama_pos(prefixCacheCount), -1)
             debug("new pos max:", llama_kv_cache_seq_pos_max(self.context, seqId), "commonTokens:", commonTokens.count)
+            #else
+            llama_memory_seq_rm(memory, seqId, llama_pos(prefixCacheCount), -1)
+            debug("new pos max:", llama_memory_seq_pos_max(memory, seqId), "commonTokens:", commonTokens.count)
+            #endif
         }
         self.batch.n_tokens = 0
         let n_ctx = llama_n_ctx(context)

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -46,6 +46,89 @@ private final class ZenzTokenArrayBox {
     let tokens: [llama_token]
 }
 
+struct ZenzResolvedConversionCacheKey: Equatable, Hashable {
+    var dictionaryIdentifier: ObjectIdentifier
+    var input: [ComposingText.InputElement]
+    var convertTarget: String
+    var convertTargetCursorPosition: Int?
+    var keyboardLanguage: KeyboardLanguage
+    var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+}
+
+struct ZenzResolvedConversion {
+    var resultPrevs: [RegisteredNode]
+    var resultLatticeHead: ZenzResolvedLatticeHead
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+    var satisfyingCandidate: Candidate
+}
+
+struct ZenzResolvedLatticeNode: Hashable {
+    var data: DicdataElement
+    var range: Lattice.LatticeRange
+}
+
+final class ZenzResolvedLatticeHead: @unchecked Sendable {
+    init(nodes: [ZenzResolvedLatticeNode]) {
+        self.nodes = nodes
+        self.fingerprint = nodes.hashValue
+    }
+
+    let nodes: [ZenzResolvedLatticeNode]
+    let fingerprint: Int
+}
+
+private final class ZenzResolvedConversionCache: @unchecked Sendable {
+    private struct Entry {
+        var value: ZenzResolvedConversion
+        var accessIndex: UInt64
+    }
+
+    init(capacity: Int) {
+        self.capacity = capacity
+    }
+
+    func value(for key: ZenzResolvedConversionCacheKey) -> ZenzResolvedConversion? {
+        self.lock.withLock {
+            guard var entry = self.entries[key] else {
+                return nil
+            }
+            self.accessIndex &+= 1
+            entry.accessIndex = self.accessIndex
+            self.entries[key] = entry
+            return entry.value
+        }
+    }
+
+    func insert(_ value: ZenzResolvedConversion, for key: ZenzResolvedConversionCacheKey) {
+        var value = value
+        self.lock.withLock {
+            // 逐次入力では最大辞書長を超えた後の先頭候補が同一になる。
+            // 不変配列を既存entryと共有し、prefixごとの重複保持を避ける。
+            if let sharedHead = self.entries.values.lazy.map({
+                $0.value.resultLatticeHead
+            }).first(where: {
+                $0.fingerprint == value.resultLatticeHead.fingerprint
+                    && $0.nodes == value.resultLatticeHead.nodes
+            }) {
+                value.resultLatticeHead = sharedHead
+            }
+            self.accessIndex &+= 1
+            self.entries[key] = Entry(value: value, accessIndex: self.accessIndex)
+            if self.entries.count > self.capacity,
+               let oldestKey = self.entries.min(by: {
+                   $0.value.accessIndex < $1.value.accessIndex
+               })?.key {
+                self.entries.removeValue(forKey: oldestKey)
+            }
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [ZenzResolvedConversionCacheKey: Entry] = [:]
+    private var accessIndex: UInt64 = 0
+    private let lock = NSLock()
+}
+
 /// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
 ///
 /// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
@@ -84,6 +167,7 @@ private final class SharedZenzModel {
         self.model = model
         self.vocab = vocab
         self.evaluationCache = ZenzEvaluationCache(capacity: 256)
+        self.resolvedConversionCache = ZenzResolvedConversionCache(capacity: 64)
         self.evaluationPromptTokenCache.countLimit = 128
     }
 
@@ -94,6 +178,7 @@ private final class SharedZenzModel {
     let model: OpaquePointer
     let vocab: OpaquePointer
     let evaluationCache: ZenzEvaluationCache
+    fileprivate let resolvedConversionCache: ZenzResolvedConversionCache
     let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
 }
 
@@ -155,6 +240,9 @@ final class ZenzContext {
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
+        #if Zenzai || ZenzaiCPU
+        ctx_params.n_ubatch = 64
+        #endif
         ctx_params.flash_attn = true
         return ctx_params
     }
@@ -313,6 +401,19 @@ final class ZenzContext {
 
     func cacheEvaluation(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
         self.sharedModel.evaluationCache.insert(result, for: key)
+    }
+
+    func cachedResolvedConversion(
+        for key: ZenzResolvedConversionCacheKey
+    ) -> ZenzResolvedConversion? {
+        self.sharedModel.resolvedConversionCache.value(for: key)
+    }
+
+    func cacheResolvedConversion(
+        _ value: ZenzResolvedConversion,
+        for key: ZenzResolvedConversionCacheKey
+    ) {
+        self.sharedModel.resolvedConversionCache.insert(value, for: key)
     }
 
     func normalizeForModel(_ text: String) -> String {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -36,6 +36,7 @@ package func llama_backend_free() {}
 
 package struct llama_model_params {
     package var use_mmap: Bool
+    package var use_extra_bufts: Bool
 }
 package func llama_model_default_params() -> llama_model_params { unimplemented() }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -11,10 +11,14 @@ package typealias llama_seq_id = Int32
 package struct llama_context_params {
     package var seed: Int
     package var n_ctx: Int
+    package var n_seq_max: Int
+    package var kv_unified: Bool
     package var n_threads: Int32
     package var n_threads_batch: Int32
     package var n_batch: Int
     package var flash_attn: Bool
+    package var flash_attn_type: Int32
+    package var no_perf: Bool
 }
 package func llama_context_default_params() -> llama_context_params { unimplemented() }
 
@@ -42,6 +46,13 @@ package func llama_model_load_from_file(_: String, _: llama_model_params) -> lla
 package func llama_kv_cache_seq_rm(_: llama_context, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
 package func llama_kv_cache_seq_cp(_: llama_context, _: llama_seq_id, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
 package func llama_kv_cache_seq_pos_max(_: llama_context, _: llama_seq_id) -> Int { unimplemented() }
+
+package let LLAMA_FLASH_ATTN_TYPE_ENABLED: Int32 = 1
+package typealias llama_memory = OpaquePointer
+package func llama_get_memory(_: llama_context) -> llama_memory { unimplemented() }
+package func llama_memory_seq_rm(_: llama_memory, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
+package func llama_memory_seq_cp(_: llama_memory, _: llama_seq_id, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
+package func llama_memory_seq_pos_max(_: llama_memory, _: llama_seq_id) -> Int { unimplemented() }
 
 package struct llama_batch {
     package var token: [llama_token]

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -10,12 +10,44 @@ extension Kana2Kanji {
             self.prefixConstraint = constraint
             self.satisfyingCandidate = satisfyingCandidate
             self.cachedLattice = lattice
+            self.cachedLatticeInputData = lattice == nil ? nil : inputData
+        }
+
+        private init(
+            _ inputData: ComposingText,
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate?,
+            cachedLattice: Lattice?,
+            cachedLatticeInputData: ComposingText?
+        ) {
+            self.inputData = inputData
+            self.prefixConstraint = constraint
+            self.satisfyingCandidate = satisfyingCandidate
+            self.cachedLattice = cachedLattice
+            self.cachedLatticeInputData = cachedLatticeInputData
         }
 
         private var prefixConstraint: PrefixConstraint
         private var satisfyingCandidate: Candidate?
         private var inputData: ComposingText
         private var cachedLattice: Lattice?
+        private var cachedLatticeInputData: ComposingText?
+
+        /// 共有済みの変換結果を使う場合、現在の制約だけを更新し、直近の完全な
+        /// ラティスは次の未キャッシュ入力の差分構築用アンカーとして保持する。
+        func updatingResult(
+            for newInputData: ComposingText,
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate
+        ) -> ZenzaiCache {
+            ZenzaiCache(
+                newInputData,
+                constraint: constraint,
+                satisfyingCandidate: satisfyingCandidate,
+                cachedLattice: self.cachedLattice,
+                cachedLatticeInputData: self.cachedLatticeInputData
+            )
+        }
 
         func getNewConstraint(for newInputData: ComposingText) -> PrefixConstraint {
             if let satisfyingCandidate {
@@ -37,10 +69,11 @@ extension Kana2Kanji {
         }
 
         func getPreprocessedLattice(for newInputData: ComposingText, kanaKanji: Kana2Kanji, dicdataStoreState: DicdataStoreState) -> Lattice? {
-            guard let cachedLattice else { return nil }
+            guard let cachedLattice, let cachedLatticeInputData else { return nil }
 
             // 同じComposingTextなら既存のlatticeをそのまま返す
-            if newInputData.input == inputData.input && newInputData.convertTarget == inputData.convertTarget {
+            if newInputData.input == cachedLatticeInputData.input
+                && newInputData.convertTarget == cachedLatticeInputData.convertTarget {
                 cachedLattice.resetNodeStates()
                 return cachedLattice
             }
@@ -50,7 +83,7 @@ extension Kana2Kanji {
                 inputData: newInputData,
                 inputCount: newInputData.input.count,
                 surfaceCount: newInputData.convertTarget.count,
-                incrementalCacheInfo: (inputData: inputData, lattice: cachedLattice),
+                incrementalCacheInfo: (inputData: cachedLatticeInputData, lattice: cachedLattice),
                 dicdataStoreState: dicdataStoreState
             )
         }
@@ -89,12 +122,81 @@ extension Kana2Kanji {
     ) -> (result: LatticeNode, lattice: Lattice, cache: ZenzaiCache) {
         let latticeInputData = Self.zenzaiLatticeInputData(for: inputData)
         let zenzInputCursorPosition = Self.zenzaiInputCursorPosition(for: inputData)
+        let inputStyle = inputData.input.last?.inputStyle ?? .direct
+        let defersEvaluationForPendingInput = !requestRichCandidates
+            && personalizationMode == nil
+            && self.resolvePredictiveInputSource(
+                composingText: inputData,
+                inputStyle: inputStyle
+            ).droppedSuffixCount > 0
+        let resolvedConversionCacheKey: ZenzResolvedConversionCacheKey? =
+            if !requestRichCandidates,
+               personalizationMode == nil,
+               dicdataStoreState.canShareStaticConversionResults() {
+                ZenzResolvedConversionCacheKey(
+                    dictionaryIdentifier: ObjectIdentifier(self.dicdataStore),
+                    input: latticeInputData.input,
+                    convertTarget: latticeInputData.convertTarget,
+                    convertTargetCursorPosition: zenzInputCursorPosition,
+                    keyboardLanguage: dicdataStoreState.keyboardLanguage,
+                    versionDependentConfig: versionDependentConfig
+                )
+            } else {
+                nil
+            }
+        if let resolvedConversionCacheKey,
+           let cached = zenz.cachedResolvedConversion(for: resolvedConversionCacheKey) {
+            // 全文経路とは別にprocessResultが参照する先頭辞書ノードだけを復元する。
+            // 可変な探索状態を持つラティス本体は共有しない。
+            let lattice = Lattice(
+                inputCount: latticeInputData.input.count,
+                surfaceCount: latticeInputData.convertTarget.count,
+                rawNodes: [
+                    cached.resultLatticeHead.nodes.map {
+                        LatticeNode(data: $0.data, range: $0.range)
+                    }
+                ]
+            )
+            let eosNode = LatticeNode.EOSNode
+            eosNode.prevs = cached.resultPrevs
+            let nextCache = zenzaiCache?.updatingResult(
+                for: latticeInputData,
+                constraint: cached.prefixConstraint,
+                satisfyingCandidate: cached.satisfyingCandidate
+            ) ?? ZenzaiCache(
+                latticeInputData,
+                constraint: cached.prefixConstraint,
+                satisfyingCandidate: cached.satisfyingCandidate
+            )
+            return (
+                eosNode,
+                lattice,
+                nextCache
+            )
+        }
         var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
+        let incrementalPrefixConstraint: PrefixConstraint? = if zenzaiCache != nil,
+                                                                inputData.input.last?.inputStyle == .direct {
+            constraint
+        } else {
+            nil
+        }
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
         var constructedCandidates: [(RegisteredNode, Candidate)] = []
         var insertedCandidates: [(RegisteredNode, Candidate)] = []
+        func makeCache(
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate?
+        ) -> ZenzaiCache {
+            ZenzaiCache(
+                latticeInputData,
+                constraint: constraint,
+                satisfyingCandidate: satisfyingCandidate,
+                lattice: lattice
+            )
+        }
         defer {
             eosNode.prevs = insertedCandidates.map(\.0)
         }
@@ -116,8 +218,16 @@ extension Kana2Kanji {
                 // 実験の結果、ここは2-bestを取ると平均的な速度が最良になることがわかったので、そうしている。
                 draftResult = self.kana2lattice_all(latticeInputData, N_best: 2, needTypoCorrection: false, preprocessedLattice: preprocessedLattice, dicdataStoreState: dicdataStoreState)
             } else {
-                // 制約がついている場合は高速になるので、N=3としている
-                draftResult = self.kana2lattice_all_with_prefix_constraint(latticeInputData, N_best: 3, constraint: constraint, preprocessedLattice: preprocessedLattice, dicdataStoreState: dicdataStoreState)
+                // rich候補を要求しない通常モードでは最良経路しか消費しない。
+                // rich候補用の代替制約探索では従来どおり3-bestを保持する。
+                let constrainedNBest = requestRichCandidates ? 3 : 1
+                draftResult = self.kana2lattice_all_with_prefix_constraint(
+                    latticeInputData,
+                    N_best: constrainedNBest,
+                    constraint: constraint,
+                    preprocessedLattice: preprocessedLattice,
+                    dicdataStoreState: dicdataStoreState
+                )
             }
             if lattice.isEmpty {
                 // 初回のみ
@@ -137,7 +247,7 @@ extension Kana2Kanji {
                 debug("best was not found!")
                 // Emptyの場合
                 // 制約が満たせない場合は無視する
-                return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: PrefixConstraint([]), satisfyingCandidate: nil, lattice: lattice))
+                return (eosNode, lattice, makeCache(constraint: PrefixConstraint([]), satisfyingCandidate: nil))
             }
 
             debug("Constrained draft modeling", -start.timeIntervalSinceNow)
@@ -148,7 +258,17 @@ extension Kana2Kanji {
                 if inferenceLimit == 0 {
                     debug("inference limit! \(candidate.text) is used for excuse")
                     // When inference occurs more than maximum times, then just return result at this point
-                    return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: constraint, satisfyingCandidate: candidate, lattice: lattice))
+                    return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: candidate))
+                }
+                if defersEvaluationForPendingInput {
+                    // ローマ字表で未確定のsuffixは、次のキーでかなへ置換される。
+                    // モデルが未確定ASCIIを評価しても結果を再利用できないため、
+                    // かな列が確定するまで辞書変換結果を保持する。
+                    return (
+                        eosNode,
+                        lattice,
+                        makeCache(constraint: constraint, satisfyingCandidate: candidate)
+                    )
                 }
                 let reviewResult = zenz.candidateEvaluate(
                     convertTarget: inputData.convertTarget,
@@ -156,6 +276,7 @@ extension Kana2Kanji {
                     candidates: [candidate],
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: constraint,
+                    incrementalPrefixConstraint: incrementalPrefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig
                 )
@@ -204,9 +325,36 @@ extension Kana2Kanji {
                         }
                     }
                     if satisfied {
-                        return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: constraint, satisfyingCandidate: candidate, lattice: lattice))
+                        if let resolvedConversionCacheKey,
+                           insertedCandidates.allSatisfy({
+                               $0.1.data.allSatisfy {
+                                   $0.metadata.isDisjoint(
+                                       with: [.isLearned, .isFromUserDictionary]
+                                   )
+                               }
+                           }) {
+                            zenz.cacheResolvedConversion(
+                                ZenzResolvedConversion(
+                                    resultPrevs: insertedCandidates.map(\.0),
+                                    resultLatticeHead: ZenzResolvedLatticeHead(
+                                        nodes: lattice[
+                                            index: .bothIndex(inputIndex: 0, surfaceIndex: 0)
+                                        ].map {
+                                            ZenzResolvedLatticeNode(
+                                                data: $0.data,
+                                                range: $0.range
+                                            )
+                                        }
+                                    ),
+                                    prefixConstraint: constraint,
+                                    satisfyingCandidate: candidate
+                                ),
+                                for: resolvedConversionCacheKey
+                            )
+                        }
+                        return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: candidate))
                     } else {
-                        return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: constraint, satisfyingCandidate: nil, lattice: lattice))
+                        return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: nil))
                     }
                 case .continue:
                     break reviewLoop

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -175,12 +175,6 @@ extension Kana2Kanji {
             )
         }
         var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
-        let incrementalPrefixConstraint: PrefixConstraint? = if zenzaiCache != nil,
-                                                                inputData.input.last?.inputStyle == .direct {
-            constraint
-        } else {
-            nil
-        }
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
@@ -276,7 +270,6 @@ extension Kana2Kanji {
                     candidates: [candidate],
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: constraint,
-                    incrementalPrefixConstraint: incrementalPrefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig
                 )

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -203,7 +203,7 @@ public final class KanaKanjiConverter {
             return model
         } else {
             do {
-                self.zenz = try Zenz(resourceURL: modelURL)
+                self.zenz = try Zenz.shared(resourceURL: modelURL)
                 self.sessions = self.sessions.mapValues { state in
                     let next = state
                     next.zenzaiTypoCache.invalidateForModelChange()
@@ -1135,7 +1135,6 @@ public final class KanaKanjiConverter {
         guard let result = self.convertToLattice(inputData, N_best: options.N_best, zenzaiMode: options.zenzaiMode, needTypoCorrection: needTypoCorrection) else {
             return ConversionResult(mainResults: [], predictionResults: [], englishPredictionResults: [], firstClauseResults: [])
         }
-
         return self.processResult(inputData: inputData, result: result, options: options)
     }
 

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/SpellChecker.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/SpellChecker.swift
@@ -15,6 +15,27 @@ import AppKit
 final class SpellChecker {
     init() {}
 
+    private final class CompletionCacheEntry {
+        init(_ completions: [String]?) {
+            self.completions = completions
+        }
+
+        let completions: [String]?
+    }
+
+    private final class CompletionCache: @unchecked Sendable {
+        init() {
+            self.storage.countLimit = 128
+            self.storage.totalCostLimit = 1 * 1024 * 1024
+        }
+
+        let storage = NSCache<NSString, CompletionCacheEntry>()
+    }
+
+    /// OSの補完器は同じ接頭辞に対しても比較的高コストなため、複数の変換器で共有する。
+    /// NSCacheによりメモリプレッシャー時は自動的に破棄される。
+    private static let completionCache = CompletionCache()
+
     #if os(iOS) || os(tvOS) || os(visionOS)
     // UITextChecker is main-actor isolated on iOS-family platforms.
     // Use a static instance to avoid capturing `self` in main-actor closures.
@@ -24,22 +45,45 @@ final class SpellChecker {
     #endif
 
     func completions(forPartialWordRange range: NSRange, in string: String, language: String) -> [String]? {
+        let cacheKey = "\(language)\u{0}\(range.location):\(range.length)\u{0}\(string)" as NSString
+        if let cached = Self.completionCache.storage.object(forKey: cacheKey) {
+            return cached.completions
+        }
+        let completions: [String]?
         #if os(iOS) || os(tvOS) || os(visionOS)
         if Thread.isMainThread {
             // Already on main thread: enter main-actor context synchronously.
-            return MainActor.assumeIsolated { Self.checker.completions(forPartialWordRange: range, in: string, language: language) }
+            completions = MainActor.assumeIsolated {
+                Self.checker.completions(
+                    forPartialWordRange: range,
+                    in: string,
+                    language: language
+                )
+            }
         } else {
             // Hop to main thread synchronously and run in main-actor context.
             var result: [String]?
             DispatchQueue.main.sync {
                 result = MainActor.assumeIsolated { Self.checker.completions(forPartialWordRange: range, in: string, language: language) }
             }
-            return result
+            completions = result
         }
         #elseif os(macOS)
-        return checker.completions(forPartialWordRange: range, in: string, language: language, inSpellDocumentWithTag: 0)
+        completions = checker.completions(
+            forPartialWordRange: range,
+            in: string,
+            language: language,
+            inSpellDocumentWithTag: 0
+        )
         #else
-        return nil
+        completions = nil
         #endif
+        let cost = completions?.reduce(32) { $0 + 16 + $1.utf8.count } ?? 16
+        Self.completionCache.storage.setObject(
+            CompletionCacheEntry(completions),
+            forKey: cacheKey,
+            cost: cost
+        )
+        return completions
     }
 }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStoreState.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStoreState.swift
@@ -25,10 +25,12 @@ package final class DicdataStoreState {
 
     private(set) var memoryHasLoaded: Bool = false
     private(set) var memoryLOUDS: LOUDS?
+    private var staticConversionCacheEligibility: Bool?
 
     func updateUserDictionaryURL(_ newURL: URL, forceReload: Bool) {
         if self.userDictionaryURL != newURL || forceReload {
             self.userDictionaryURL = newURL
+            self.staticConversionCacheEligibility = nil
             self.userDictionaryLOUDS = nil
             self.userDictionaryHasLoaded = false
             self.userShortcutsLOUDS = nil
@@ -42,6 +44,7 @@ package final class DicdataStoreState {
 
     func updateLearningConfig(_ newConfig: LearningConfig) {
         if self.learningMemoryManager.config != newConfig {
+            self.staticConversionCacheEligibility = nil
             let updated = self.learningMemoryManager.updateConfig(newConfig)
             if updated {
                 self.resetMemoryLOUDSCache()
@@ -75,6 +78,7 @@ package final class DicdataStoreState {
     }
 
     func importDynamicUserDictionary(_ dicdata: [DicdataElement], shortcuts: [DicdataElement] = []) {
+        self.staticConversionCacheEligibility = nil
         self.dynamicUserDictionary = dicdata
         self.dynamicUserDictionary.mutatingForEach {
             $0.metadata = .isFromUserDictionary
@@ -83,6 +87,39 @@ package final class DicdataStoreState {
         self.dynamicUserShortcuts.mutatingForEach {
             $0.metadata = .isFromUserDictionary
         }
+    }
+
+    /// 辞書状態を跨いで変換結果を共有しても安全かを返す。
+    ///
+    /// 学習・動的辞書・永続ユーザ辞書のいずれかが有効な場合は、同じ入力でも
+    /// 候補列が変わり得るため共有しない。
+    func canShareStaticConversionResults() -> Bool {
+        if let staticConversionCacheEligibility {
+            return staticConversionCacheEligibility
+        }
+        guard self.learningMemoryManager.config.learningType == .nothing,
+              self.dynamicUserDictionary.isEmpty,
+              self.dynamicUserShortcuts.isEmpty else {
+            self.staticConversionCacheEligibility = false
+            return false
+        }
+        guard let userDictionaryURL else {
+            self.staticConversionCacheEligibility = true
+            return true
+        }
+        let userDictionaryFiles = [
+            "user.loudschars2",
+            "user.louds",
+            "user_shortcuts.loudschars2",
+            "user_shortcuts.louds"
+        ]
+        let hasUserDictionaryFile = userDictionaryFiles.contains {
+            FileManager.default.fileExists(
+                atPath: userDictionaryURL.appendingPathComponent($0).path
+            )
+        }
+        self.staticConversionCacheEligibility = !hasUserDictionaryFile
+        return !hasUserDictionaryFile
     }
 
     private func resetMemoryLOUDSCache() {

--- a/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
@@ -108,11 +108,19 @@ public struct ComposingText: Sendable {
         var convertedLength = 0
 
         for (currentInputIndex, element) in input.enumerated() {
+            let previousElementCount = converting.count
+            let previousTailCount = converting.last?.string.count ?? 0
             // 現在の文字を入力した際に関連(依存)した文字列の長さ
             let deletedCount = Self.updateConvertTargetElements(currentElements: &converting, newElement: element)
 
             let previousConvertedLength = convertedLength
-            convertedLength = converting.reduce(0) { $0 + $1.string.count }
+            let currentTailCount = converting.last?.string.count ?? 0
+            if converting.count == previousElementCount {
+                convertedLength += currentTailCount - previousTailCount
+            } else {
+                // 入力方式が変わり、新しい独立した末尾要素が追加された。
+                convertedLength += currentTailCount
+            }
 
             // 今回の文字入力による変換が、前の暫定独立セグメントの文字を含むローマ字テーブルエントリによって行われた場合
             // 入力は前のセグメントに依存しているので、前のセグメントとの境界を消し、より長い独立セグメントにする
@@ -383,8 +391,25 @@ public struct ComposingText: Sendable {
         // [き, ょ, う, は, い, い, て, ん, き, だ]
         // i2c: [0: 0, 3: 2(きょ), 4: 3(う), 6: 4(は), 7: 5(い), 8: 6(い), 10: 7(て), 13: 9(んき), 15: 10(だ)]
 
+        if self.hasIdentityInputSurfaceIndexMapping {
+            return Dictionary(uniqueKeysWithValues: (0 ... self.input.count).map { ($0, $0) })
+        }
+
         let segmentBoundaries = getIndependentSegmentBoundaries()
         return Dictionary(segmentBoundaries.map { ($0.inputIndex, $0.surfaceIndex) }) { _, second in second }
+    }
+
+    var hasIdentityInputSurfaceIndexMapping: Bool {
+        self.input.count == self.convertTarget.count
+            && self.input.allSatisfy {
+                guard $0.inputStyle == .direct else {
+                    return false
+                }
+                if case .character = $0.piece {
+                    return true
+                }
+                return false
+            }
     }
 
     public mutating func stopComposition() {
@@ -497,7 +522,7 @@ extension ComposingText {
 
 // Equatableにしておく
 extension ComposingText: Equatable {}
-extension ComposingText.InputElement: Equatable {}
+extension ComposingText.InputElement: Hashable {}
 extension ComposingText.ConvertTargetElement: Equatable {
     static func == (lhs: ComposingText.ConvertTargetElement, rhs: ComposingText.ConvertTargetElement) -> Bool {
         lhs.inputStyle == rhs.inputStyle && lhs.string == rhs.string


### PR DESCRIPTION
## 概要

ZenzaiのCPU推論とincrementalかな漢字変換を、Direct / Roman2Kana / AZIKのいずれでも高速化します。さらにllama.cppをb4846からb9637へ更新し、macOSとiOS 17向けのCPU実行を整理します。

主な変更は以下です。

- incremental入力の差分だけを処理するlattice再利用と、prefix制約付きN=1処理の高速化
- 同一モデルのweight / vocabulary共有と、入力token prefixが一致する場合のKV cache再利用
- prompt・評価結果・安全に再利用できる変換結果の上限付きLRU cache
- top-1推論、logits参照、llama batch / micro-batch、CPU thread数の最適化
- Direct入力のidentity mapping、Roman2Kana / AZIKの未確定suffix処理の削減
- SpellChecker / N-best lattice payload / LOUDSの省メモリ化
- llama.cpp b9637の新memory API、共有KV cache、CPU weight repackへの対応
- deployment targetをiOS 17へ更新

Direct stable-prefix projectionは意味保存を厳密に保証できないため削除済みです。代わりに、候補token `i` の判定にはtoken `i - 1` のlogitsまであれば十分という依存関係を利用し、最終候補tokenの不要なdecodeを除去しました。評価対象は一括decodeし、llama.cpp内部の未使用perf統計も無効化しています。これらは候補判定を省略・近似しない変更です。

## llama.cpp更新

ZenzaiのGGUFには固有の `tokenizer.ggml.pre = gpt2-small-japanese-char` が記録されており、本家b9637は未知のpre-tokenizerとしてモデルのloadを拒否します。標準の `gpt-2` へmetadata overrideするとload自体は成功しますが、raw ASCII spaceを含む入力でtoken列が変わるため、安全な代替にはできませんでした。

そのため、[b9637-azookey.1](https://github.com/azooKey/llama.cpp/releases/tag/b9637-azookey.1) を使用します。本家b9637との差分は次の互換処理に限定しています。

- `gpt2-small-japanese-char` tokenizerの登録と、従来どおりのspecial token / space / newline処理
- CPU-only実行でMetal shaderのcold-startを避ける `GGML_DISABLE_METAL`

公式b9637そのままではCPU-onlyでもMetal初期化に約9.4秒かかりましたが、互換版では約0.3秒で最初の変換を完了します。Swift側はAppleではb9637の新memory APIを使い、Linux / Windowsのsystem-library構成では従来のKV-cache APIを維持します。

## 性能

M2 Pro / release build / 独立プロセス5回平均。比較元は `agent/optimize-zenzai-cpu-memory` です。macOSではb9637のCPU weight repackを有効にしています。

| テスト | before | after | 高速化 |
|---|---:|---:|---:|
| `testFullConversion` | 0.495 s | 0.329 s | 1.50x |
| `testGradualConversion` | 3.700 s | 1.294 s | **2.86x** |
| `testGradualConversion_Roman2Kana` | 7.423 s | 2.383 s | **3.11x** |
| `testGradualConversion_AZIK` | 5.815 s | 1.954 s | **2.98x** |

要求単位latencyの5回平均も平均10 ms / p90 25 msの両目標を満たします。

| ケース | 平均 | p90 |
|---|---:|---:|
| Direct | 4.16 ms | 14.43 ms |
| Roman2Kana | 4.72 ms | 11.61 ms |
| AZIK | 4.62 ms | 11.88 ms |

b9637更新前のこのPRの安全なprojection-off状態と比べても、macOSではDirect 1.798 → 1.294秒、Roman2Kana 2.603 → 2.383秒、AZIK 2.147 → 1.954秒です。

## メモリ

converter側の削減は以下です。

- N-best payload共有: peak footprint 57.32 MiB → 53.32 MiB（-3.82 MiB、-7.0%）、実行時間は実質同等
- LOUDSのUInt32化: 長文Direct incrementalケースで約1.65 MiB削減、約4%高速化
- 変換結果LRU（最大64件）と共有headの追加コスト: peak footprint約+0.19 MiB
- llama compute buffer: 約14.7 MiB → 1.84〜2.03 MiB（約12.7 MiB削減）
- 同一モデルのweight / vocabularyを共有し、converterごとの約70 MiBのmodel mapping重複を防止
- KV cacheなどの可変状態は各推論contextに分離し、512 token / 18 MiBを維持

b9637既定のCPU weight repackは速度に効く一方、モデルと同程度の追加bufferを常駐させます。独立XCTestプロセスのDirectケースでは、b4846のpeak footprint 72.8 MiBに対し、b9637 + repackは135.0 MiBでした。

iOSのZenzai CPUでは `use_extra_bufts = false` を設定し、repackを無効化します。同じ設定をM2 Proで測ると70.9 MiBで、約64 MiBを回収し、b4846同等以下に戻りました。iOS向けの速度トレードオフを同じMac上で代理計測すると次の通りです。

| テスト | b4846 | b9637 / repack無効 | 差 |
|---|---:|---:|---:|
| Full | 0.325 s | 0.346 s | +6.6% |
| Direct | 1.798 s | 1.842 s | +2.4% |
| Roman2Kana | 2.603 s | 2.760 s | +6.0% |
| AZIK | 2.147 s | 1.728 s | -19.5% |

macOSは速度を優先してrepackを有効、メモリ制約の厳しいiOSは無効、というプラットフォーム別設定です。

## 検証

- `xcrun swift build -c release`: 成功
- `xcrun swift test -c release --traits ZenzaiCPU`: 180 tests passed
- Zenzaiの5ケース: すべて成功
- `arm64-apple-ios17.0` / `ZenzaiCPU` cross build: 成功
- iOS生成物: `platform IOS`, `minos 17.0` を確認
- CPU device、GPU layer 0、KQV offload無効、macOS CPU-only時のMetal無効化を確認