### PR TITLE
perf(zenzai): Roman/AZIKのdraftingを高速化

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -4,7 +4,11 @@ import SwiftUtils
 
 extension Kana2Kanji {
     // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
-    private func computeMatchedAndTotalLength(prev: RegisteredNode?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
+    private func computeMatchedAndTotalLength(
+        prev: borrowing RegisteredNode?,
+        currentWord: borrowing String,
+        constraintBytes: borrowing [UInt8]
+    ) -> (matched: Int, total: Int) {
         let previousTotal = prev.map { Int($0.candidateUTF8Count) } ?? 0
         var matched = prev.map { Int($0.constraintMatchedUTF8Count) } ?? 0
         let total = previousTotal + currentWord.utf8.count
@@ -24,7 +28,11 @@ extension Kana2Kanji {
     }
 
     // Extend match with next word starting from current matched index
-    private func extendMatched(matched: Int, nextWord: String, constraintBytes: [UInt8]) -> (matched: Int, mismatch: Bool) {
+    private func extendMatched(
+        matched: Int,
+        nextWord: borrowing String,
+        constraintBytes: borrowing [UInt8]
+    ) -> (matched: Int, mismatch: Bool) {
         var ci = matched
         if ci >= constraintBytes.count {
             return (ci, false)
@@ -99,6 +107,9 @@ extension Kana2Kanji {
                 rawNodes: rawNodes
             )
         }
+        let constraintBytes = constraint.constraint
+        let constraintLength = constraintBytes.count
+        let enforcesConstraintOnStaticDictionary = !constraint.ignoreMemoryAndUserDictionary
         // 「i文字目から始まるnodes」に対して
         for (isHead, nodeArray) in lattice.indexedNodes(indices: latticeIndices) {
             // それぞれのnodeに対して
@@ -114,16 +125,13 @@ extension Kana2Kanji {
                             : 0
                     )
                     let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
-                    let constraintBytes = constraint.constraint
                     let matchState = self.computeMatchedAndTotalLength(
                         prev: previous,
                         currentWord: node.data.word,
                         constraintBytes: constraintBytes
                     )
-                    let constraintLength = constraintBytes.count
-
                     if nextIndex.surfaceIndex == surfaceCount {
-                        if !constraint.ignoreMemoryAndUserDictionary,
+                        if enforcesConstraintOnStaticDictionary,
                            node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let condition = if constraint.hasEOS {
                                 matchState.matched == constraintLength
@@ -157,7 +165,7 @@ extension Kana2Kanji {
                            current.totalValue >= newValue {
                             continue
                         }
-                        if !constraint.ignoreMemoryAndUserDictionary,
+                        if enforcesConstraintOnStaticDictionary,
                            nextNode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             guard matchState.matched
                                 == min(matchState.total, constraintLength) else {
@@ -208,22 +216,21 @@ extension Kana2Kanji {
                 // 変換した文字数
                 let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
                 // 文字数がcountと等しい場合登録する
-                let constraintBytes = constraint.constraint
                 if nextIndex.surfaceIndex == surfaceCount {
                     // Precompute matched/total lengths per prev for (prev + current word)
                     let mtPerPrev: [(matched: Int, total: Int)] = node.prevs.indices.map { idx in
                         self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
                     }
-                    let cLen = constraintBytes.count
                     for index in node.prevs.indices {
                         // 学習データやユーザ辞書由来の場合は素通しする
-                        if !constraint.ignoreMemoryAndUserDictionary, node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                        if enforcesConstraintOnStaticDictionary,
+                           node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let (matched, total) = mtPerPrev[index]
                             // 最終チェック（EOS時の条件に合わせる）
                             let condition = if constraint.hasEOS {
-                                matched == cLen && total == cLen
+                                matched == constraintLength && total == constraintLength
                             } else {
-                                matched == cLen
+                                matched == constraintLength
                             }
                             guard condition else {
                                 continue
@@ -251,7 +258,6 @@ extension Kana2Kanji {
                     let mtPerPrev: [(matched: Int, total: Int)] = node.prevs.indices.map { idx in
                         self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
                     }
-                    let cLen = constraintBytes.count
                     let ccLatter = self.dicdataStore.getCCLatter(node.data.rcid)
                     // nodeの繋がる次にあり得る全てのnextnodeに対して
                     for nextnode in lattice[index: nextIndex] {
@@ -271,10 +277,11 @@ extension Kana2Kanji {
                             // 制約 AB 単語 A   (OK)
                             // 制約 AB 単語 AC  (NG)
                             // ただし、学習データやユーザ辞書由来の場合は素通しする
-                            if !constraint.ignoreMemoryAndUserDictionary, nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            if enforcesConstraintOnStaticDictionary,
+                               nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                                 let (matchedPrev, totalPrev) = mtPerPrev[index]
                                 // ensure no prior mismatch
-                                guard matchedPrev == min(totalPrev, cLen) else {
+                                guard matchedPrev == min(totalPrev, constraintLength) else {
                                     continue
                                 }
                                 let nextLen = nextnode.data.word.utf8.count
@@ -286,10 +293,11 @@ extension Kana2Kanji {
                                 let newTotal = totalPrev + nextLen
                                 let ok: Bool = if constraint.hasEOS {
                                     // require strict prefix of constraint
-                                    matchedExt == newTotal && newTotal < cLen
+                                    matchedExt == newTotal && newTotal < constraintLength
                                 } else {
                                     // accept either: constraint is prefix of candidate, or candidate is prefix of constraint
-                                    (matchedExt == cLen) || (newTotal <= cLen && matchedExt == newTotal)
+                                    (matchedExt == constraintLength)
+                                        || (newTotal <= constraintLength && matchedExt == newTotal)
                                 }
                                 guard ok else {
                                     continue
@@ -320,8 +328,8 @@ extension Kana2Kanji {
         inputCount: Int,
         surfaceCount: Int,
         incrementalCacheInfo: (inputData: ComposingText, lattice: Lattice)?,
-        dicdataStoreState: DicdataStoreState,
-        ) -> Lattice {
+        dicdataStoreState: DicdataStoreState
+    ) -> Lattice {
         let indexMap = LatticeDualIndexMap(inputData)
         let latticeIndices = indexMap.indices(inputCount: inputCount, surfaceCount: surfaceCount)
         guard let incrementalCacheInfo else {
@@ -362,9 +370,11 @@ extension Kana2Kanji {
         let commonInputCount = zip(oldInput, newInput).prefix { $0 == $1 }.count
         let commonSurfaceCount = zip(oldSurface, newSurface).prefix { $0 == $1 }.count
 
-        // 逐次入力でない場合（中間の文字が変わった場合）は通常の処理
-        if commonInputCount != min(oldInput.count, newInput.count) ||
-            commonSurfaceCount != min(oldSurface.count, newSurface.count) {
+        // inputの中間が変更された場合は通常の処理に戻す。
+        // Roman/AZIKの逐次入力では、inputは単純なsuffix追加でも
+        // convertTargetの未確定suffixが `k -> か` のように書き換わる。
+        // そのケースは下で独立セグメント境界まで戻し、suffixだけ作り直す。
+        if commonInputCount != oldInput.count {
             let rawNodes = latticeIndices.map { index in
                 let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex {
                     (iIndex, nil)
@@ -394,15 +404,38 @@ extension Kana2Kanji {
         // 逐次入力の場合：既存Latticeから共通部分を再利用し、新しい部分のみ辞書引き
         let cachedLattice = incrementalCacheInfo.lattice
 
+        // surfaceの末尾書き換えがある場合、commonSurfaceCountがローマ字変換の
+        // 独立セグメント内を指すことがある。その位置ではinput/surfaceの
+        // 対応が一意でないため、直前の独立セグメント境界まで戻す。
+        let reusableBoundary: (input: Int, surface: Int)
+        if commonSurfaceCount == oldSurface.count {
+            reusableBoundary = (commonInputCount, commonSurfaceCount)
+        } else {
+            reusableBoundary = incrementalCacheInfo.inputData
+                .inputIndexToSurfaceIndexMap()
+                .lazy
+                .filter { $0.value <= commonSurfaceCount }
+                .map { (input: $0.key, surface: $0.value) }
+                .max {
+                    if $0.surface == $1.surface {
+                        $0.input < $1.input
+                    } else {
+                        $0.surface < $1.surface
+                    }
+                } ?? (0, 0)
+        }
+        let reusableInputCount = reusableBoundary.input
+        let reusableSurfaceCount = reusableBoundary.surface
+
         // 純粋なsuffix追加では既存Latticeの全ノードがそのまま有効なので、
         // 各ノード配列のfilterと再構築を避ける。削除を伴う場合だけprefixを切り出す。
-        var newLattice = if commonInputCount == oldInput.count,
-                            commonSurfaceCount == oldSurface.count {
+        var newLattice = if reusableInputCount == oldInput.count,
+                            reusableSurfaceCount == oldSurface.count {
             cachedLattice
         } else {
             cachedLattice.prefix(
-                inputCount: commonInputCount,
-                surfaceCount: commonSurfaceCount
+                inputCount: reusableInputCount,
+                surfaceCount: reusableSurfaceCount
             )
         }
         newLattice.resetNodeStates()
@@ -412,24 +445,24 @@ extension Kana2Kanji {
         // 始まるノードは新規suffixへ到達できない。
         let earliestAffectedInputIndex = max(
             0,
-            commonInputCount + 1 - self.dicdataStore.maxlength
+            reusableInputCount + 1 - self.dicdataStore.maxlength
         )
         let earliestAffectedSurfaceIndex = max(
             0,
-            commonSurfaceCount + 1 - self.dicdataStore.maxlength
+            reusableSurfaceCount + 1 - self.dicdataStore.maxlength
         )
         let additionalRawNodes = latticeIndices.map { index in
             let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex,
                                                                               iIndex >= earliestAffectedInputIndex,
-                                                                              max(commonInputCount, iIndex) < inputCount {
-                (iIndex, max(commonInputCount, iIndex) ..< inputCount)
+                                                                              max(reusableInputCount, iIndex) < inputCount {
+                (iIndex, max(reusableInputCount, iIndex) ..< inputCount)
             } else {
                 nil
             }
             let surfaceRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let sIndex = index.surfaceIndex,
                                                                                 sIndex >= earliestAffectedSurfaceIndex,
-                                                                                max(commonSurfaceCount, sIndex) < surfaceCount {
-                (sIndex, max(commonSurfaceCount, sIndex) ..< surfaceCount)
+                                                                                max(reusableSurfaceCount, sIndex) < surfaceCount {
+                (sIndex, max(reusableSurfaceCount, sIndex) ..< surfaceCount)
             } else {
                 nil
             }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -77,6 +77,14 @@ package final class Zenz {
         self.zenzContext?.cacheResolvedConversion(value, for: key)
     }
 
+    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.zenzContext?.cachedDraftConversion(for: key)
+    }
+
+    func cacheDraftConversion(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
+        self.zenzContext?.cacheDraftConversion(value, for: key)
+    }
+
     func candidateEvaluate(
         convertTarget: String,
         convertTargetCursorPosition: Int? = nil,

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -60,6 +60,21 @@ struct ZenzResolvedConversionCacheKey: Equatable, Hashable {
     var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
 }
 
+struct ZenzDraftConversionCacheKey: Equatable, Hashable {
+    var dictionaryIdentifier: ObjectIdentifier
+    var input: [ComposingText.InputElement]
+    var convertTarget: String
+    var convertTargetCursorPosition: Int?
+    var keyboardLanguage: KeyboardLanguage
+    var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+}
+
+struct ZenzDraftConversion {
+    var resultPrevs: [RegisteredNode]
+    var resultLatticeHead: ZenzResolvedLatticeHead
+}
+
 struct ZenzResolvedConversion {
     var resultPrevs: [RegisteredNode]
     var resultLatticeHead: ZenzResolvedLatticeHead
@@ -134,6 +149,56 @@ private final class ZenzResolvedConversionCache: @unchecked Sendable {
     private let lock = NSLock()
 }
 
+/// 同じ辞書状態・入力・制約から得た不変のdraft経路を共有するLRU cache。
+/// 可変な探索状態を含むlattice本体は保持しない。
+final class ZenzDraftConversionCache: @unchecked Sendable {
+    private struct Entry {
+        var value: ZenzDraftConversion
+        var accessIndex: UInt64
+    }
+
+    init(capacity: Int) {
+        self.capacity = capacity
+    }
+
+    func value(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.lock.withLock {
+            guard var entry = self.entries[key] else { return nil }
+            self.accessIndex &+= 1
+            entry.accessIndex = self.accessIndex
+            self.entries[key] = entry
+            return entry.value
+        }
+    }
+
+    func insert(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
+        var value = value
+        self.lock.withLock {
+            if let sharedHead = self.entries.values.lazy.map({
+                $0.value.resultLatticeHead
+            }).first(where: {
+                $0.fingerprint == value.resultLatticeHead.fingerprint
+                    && $0.nodes == value.resultLatticeHead.nodes
+            }) {
+                value.resultLatticeHead = sharedHead
+            }
+            self.accessIndex &+= 1
+            self.entries[key] = Entry(value: value, accessIndex: self.accessIndex)
+            if self.entries.count > self.capacity,
+               let oldestKey = self.entries.min(by: {
+                   $0.value.accessIndex < $1.value.accessIndex
+               })?.key {
+                self.entries.removeValue(forKey: oldestKey)
+            }
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [ZenzDraftConversionCacheKey: Entry] = [:]
+    private var accessIndex: UInt64 = 0
+    private let lock = NSLock()
+}
+
 /// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
 ///
 /// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
@@ -178,6 +243,7 @@ private final class SharedZenzModel {
         self.vocab = vocab
         self.evaluationCache = ZenzEvaluationCache(capacity: 256)
         self.resolvedConversionCache = ZenzResolvedConversionCache(capacity: 64)
+        self.draftConversionCache = ZenzDraftConversionCache(capacity: 128)
         self.evaluationPromptTokenCache.countLimit = 128
     }
 
@@ -189,6 +255,7 @@ private final class SharedZenzModel {
     let vocab: OpaquePointer
     let evaluationCache: ZenzEvaluationCache
     fileprivate let resolvedConversionCache: ZenzResolvedConversionCache
+    fileprivate let draftConversionCache: ZenzDraftConversionCache
     let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
 }
 
@@ -452,6 +519,14 @@ final class ZenzContext {
         for key: ZenzResolvedConversionCacheKey
     ) {
         self.sharedModel.resolvedConversionCache.insert(value, for: key)
+    }
+
+    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.sharedModel.draftConversionCache.value(for: key)
+    }
+
+    func cacheDraftConversion(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
+        self.sharedModel.draftConversionCache.insert(value, for: key)
     }
 
     func normalizeForModel(_ text: String) -> String {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -178,6 +178,7 @@ extension Kana2Kanji {
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
+        var latticeIsComplete = true
         var constructedCandidates: [(RegisteredNode, Candidate)] = []
         var insertedCandidates: [(RegisteredNode, Candidate)] = []
         func makeCache(
@@ -188,29 +189,75 @@ extension Kana2Kanji {
                 latticeInputData,
                 constraint: constraint,
                 satisfyingCandidate: satisfyingCandidate,
-                lattice: lattice
+                lattice: latticeIsComplete ? lattice : nil
             )
         }
         defer {
             eosNode.prevs = insertedCandidates.map(\.0)
         }
         var inferenceLimit = inferenceLimit
+        var draftIteration = 0
         while true {
             let start = Date()
+            // 学習・ユーザ辞書・personalizationの影響がなく、入力と制約が完全一致する
+            // 初回draftだけを共有する。後続draftは直前の探索状態に依存するため対象外。
+            let draftCacheKey: ZenzDraftConversionCacheKey? = if draftIteration == 0,
+                                                                 !requestRichCandidates,
+                                                                 personalizationMode == nil,
+                                                                 dicdataStoreState.canShareStaticConversionResults() {
+                ZenzDraftConversionCacheKey(
+                    dictionaryIdentifier: ObjectIdentifier(self.dicdataStore),
+                    input: latticeInputData.input,
+                    convertTarget: latticeInputData.convertTarget,
+                    convertTargetCursorPosition: zenzInputCursorPosition,
+                    keyboardLanguage: dicdataStoreState.keyboardLanguage,
+                    versionDependentConfig: versionDependentConfig,
+                    prefixConstraint: constraint
+                )
+            } else {
+                nil
+            }
+            let cachedDraft = draftCacheKey.flatMap { zenz.cachedDraftConversion(for: $0) }
             let preprocessedLattice: Lattice?
-            if !lattice.isEmpty {
+            if cachedDraft != nil {
+                preprocessedLattice = nil
+            } else if !lattice.isEmpty {
                 // 今回の`all_zenzai`の呼び出し内部で使われているキャッシュ（lattice）が存在する場合はそちらを優先する
                 lattice.resetNodeStates()
                 preprocessedLattice = lattice
             } else {
                 // latticeがまだemptyの場合、zenzaiCache側に存在するキャッシュの活用を試みる
-                preprocessedLattice = zenzaiCache?.getPreprocessedLattice(for: latticeInputData, kanaKanji: self, dicdataStoreState: dicdataStoreState)
+                preprocessedLattice = zenzaiCache?.getPreprocessedLattice(
+                    for: latticeInputData,
+                    kanaKanji: self,
+                    dicdataStoreState: dicdataStoreState
+                )
             }
             let draftResult: (result: LatticeNode, lattice: Lattice)
-            if constraint.isEmpty {
-                // 全部を変換する場合はN=2の変換を行う
-                // 実験の結果、ここは2-bestを取ると平均的な速度が最良になることがわかったので、そうしている。
-                draftResult = self.kana2lattice_all(latticeInputData, N_best: 2, needTypoCorrection: false, preprocessedLattice: preprocessedLattice, dicdataStoreState: dicdataStoreState)
+            if let cachedDraft {
+                let cachedLattice = Lattice(
+                    inputCount: latticeInputData.input.count,
+                    surfaceCount: latticeInputData.convertTarget.count,
+                    rawNodes: [
+                        cachedDraft.resultLatticeHead.nodes.map {
+                            LatticeNode(data: $0.data, range: $0.range)
+                        }
+                    ]
+                )
+                let cachedResult = LatticeNode.EOSNode
+                cachedResult.prevs = cachedDraft.resultPrevs
+                draftResult = (cachedResult, cachedLattice)
+                // processResultが参照する先頭ノードだけを復元しているため、
+                // 後続draftのpreprocessed latticeとしては利用できない。
+                latticeIsComplete = false
+            } else if constraint.isEmpty {
+                draftResult = self.kana2lattice_all(
+                    latticeInputData,
+                    N_best: 2,
+                    needTypoCorrection: false,
+                    preprocessedLattice: preprocessedLattice,
+                    dicdataStoreState: dicdataStoreState
+                )
             } else {
                 // rich候補を要求しない通常モードでは最良経路しか消費しない。
                 // rich候補用の代替制約探索では従来どおり3-bestを保持する。
@@ -221,6 +268,21 @@ extension Kana2Kanji {
                     constraint: constraint,
                     preprocessedLattice: preprocessedLattice,
                     dicdataStoreState: dicdataStoreState
+                )
+            }
+            if let draftCacheKey, cachedDraft == nil {
+                zenz.cacheDraftConversion(
+                    ZenzDraftConversion(
+                        resultPrevs: draftResult.result.prevs,
+                        resultLatticeHead: ZenzResolvedLatticeHead(
+                            nodes: draftResult.lattice[
+                                index: .bothIndex(inputIndex: 0, surfaceIndex: 0)
+                            ].map {
+                                ZenzResolvedLatticeNode(data: $0.data, range: $0.range)
+                            }
+                        )
+                    ),
+                    for: draftCacheKey
                 )
             }
             if lattice.isEmpty {
@@ -237,6 +299,7 @@ extension Kana2Kanji {
                     best = (i, cand)
                 }
             }
+            draftIteration += 1
             guard var (index, candidate) = best else {
                 debug("best was not found!")
                 // Emptyの場合
@@ -302,7 +365,13 @@ extension Kana2Kanji {
                             } else if alternativeConstraint.probabilityRatio > 0.5 {
                                 // 十分に高い確率の場合、変換器を実際に呼び出して候補を作ってもらう
                                 lattice.resetNodeStates()
-                                let draftResult = self.kana2lattice_all_with_prefix_constraint(latticeInputData, N_best: 3, constraint: normalizedAlternativeConstraint, preprocessedLattice: lattice, dicdataStoreState: dicdataStoreState)
+                                let draftResult = self.kana2lattice_all_with_prefix_constraint(
+                                    latticeInputData,
+                                    N_best: 3,
+                                    constraint: normalizedAlternativeConstraint,
+                                    preprocessedLattice: lattice,
+                                    dicdataStoreState: dicdataStoreState
+                                )
                                 let candidates = draftResult.result.getCandidateData().map(self.processClauseCandidate)
                                 let best: (Int, Candidate)? = candidates.enumerated().reduce(into: (Int, Candidate)?.none) { best, pair in
                                     if let (_, c) = best, pair.1.value > c.value {
@@ -350,6 +419,10 @@ extension Kana2Kanji {
                         return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: nil))
                     }
                 case .continue:
+                    if !latticeIsComplete {
+                        lattice = Lattice()
+                        latticeIsComplete = true
+                    }
                     break reviewLoop
                 case .retry(let candidateIndex):
                     index = candidateIndex

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -184,6 +184,39 @@ final class ZenzPromptBuilderTests: XCTestCase {
         XCTAssertEqual(cache.value(for: third), .wholeResult("third"))
     }
 
+    func testZenzDraftConversionCacheEvictsLeastRecentlyUsedEntry() {
+        let cache = ZenzDraftConversionCache(capacity: 2)
+        let dictionary = NSObject()
+        func key(_ target: String) -> ZenzDraftConversionCacheKey {
+            ZenzDraftConversionCacheKey(
+                dictionaryIdentifier: ObjectIdentifier(dictionary),
+                input: [],
+                convertTarget: target,
+                convertTargetCursorPosition: nil,
+                keyboardLanguage: .ja_JP,
+                versionDependentConfig: .v3(.init()),
+                prefixConstraint: .init([])
+            )
+        }
+        let value = ZenzDraftConversion(
+            resultPrevs: [],
+            resultLatticeHead: .init(nodes: [])
+        )
+        let first = key("first")
+        let second = key("second")
+        let third = key("third")
+
+        cache.insert(value, for: first)
+        cache.insert(value, for: second)
+        XCTAssertNotNil(cache.value(for: first))
+
+        cache.insert(value, for: third)
+
+        XCTAssertNil(cache.value(for: second))
+        XCTAssertNotNil(cache.value(for: first))
+        XCTAssertNotNil(cache.value(for: third))
+    }
+
     func testZenzInferenceThreadCountUsesPerformanceClusterOnDarwin() {
         XCTAssertEqual(
             ZenzContext.selectInferenceThreadCount(

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import KanaKanjiConverterModule
 @testable import KanaKanjiConverterModuleWithDefaultDictionary
 import XCTest
 
@@ -69,6 +70,72 @@ final class ZenzaiTests: XCTestCase {
             typoCorrectionMode: .automatic,
             metadata: nil
         )
+    }
+
+    func testIncrementalLatticeMatchesFullRebuildForRomanAndAZIKTailRewrites() {
+        let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        let kanaKanji = Kana2Kanji(dicdataStore: dicdataStore)
+        let state = dicdataStore.prepareState()
+
+        func firstTailRewrite(
+            in sequence: String,
+            inputStyle: InputStyle
+        ) -> (old: ComposingText, new: ComposingText)? {
+            var current = ComposingText()
+            for character in sequence {
+                let old = current
+                current.insertAtCursorPosition(String(character), inputStyle: inputStyle)
+                if !old.convertTarget.isEmpty,
+                   !current.convertTarget.hasPrefix(old.convertTarget) {
+                    return (old, current)
+                }
+            }
+            return nil
+        }
+
+        func assertIncrementalMatchesFull(
+            _ pair: (old: ComposingText, new: ComposingText),
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let oldResult = kanaKanji.kana2lattice_all(
+                pair.old,
+                N_best: 2,
+                needTypoCorrection: false,
+                dicdataStoreState: state
+            )
+            let incrementalLattice = kanaKanji.buildLatticeWithIncrementalCache(
+                inputData: pair.new,
+                inputCount: pair.new.input.count,
+                surfaceCount: pair.new.convertTarget.count,
+                incrementalCacheInfo: (pair.old, oldResult.lattice),
+                dicdataStoreState: state
+            )
+            let incremental = kanaKanji.kana2lattice_all(
+                pair.new,
+                N_best: 2,
+                needTypoCorrection: false,
+                preprocessedLattice: incrementalLattice,
+                dicdataStoreState: state
+            )
+            let full = kanaKanji.kana2lattice_all(
+                pair.new,
+                N_best: 2,
+                needTypoCorrection: false,
+                dicdataStoreState: state
+            )
+            let incrementalCandidates = incremental.result.getCandidateData().map(kanaKanji.processClauseCandidate)
+            let fullCandidates = full.result.getCandidateData().map(kanaKanji.processClauseCandidate)
+            XCTAssertEqual(incrementalCandidates.map(\.text), fullCandidates.map(\.text), file: file, line: line)
+            XCTAssertEqual(incrementalCandidates.map(\.value), fullCandidates.map(\.value), file: file, line: line)
+        }
+
+        let roman = firstTailRewrite(in: "konobunshou", inputStyle: .roman2kana)
+        let azik = firstTailRewrite(in: "konobjxp", inputStyle: .mapped(id: .defaultAZIK))
+        XCTAssertNotNil(roman)
+        XCTAssertNotNil(azik)
+        if let roman { assertIncrementalMatchesFull(roman) }
+        if let azik { assertIncrementalMatchesFull(azik) }
     }
 
     func testFullConversion() async throws {


### PR DESCRIPTION
## 概要

PR #348 をベースに、Roman2Kana / AZIK入力時のCPU側draftingを高速化します。

- 同じ辞書状態・入力・prefix constraintに対する初回draft経路を128件のLRU cacheで共有
- Roman/AZIKで未確定suffixが書き換わる場合、独立セグメント境界までlatticeを安全に再利用
- prefix constraint処理の不変値をnode loop外へ移動し、不要なコピーを削減
- cacheから復元した部分latticeを後続draftの増分入力に利用しない安全策を追加

## 背景

Roman2Kana / AZIKのincremental入力では、`k -> か`のように入力自体はsuffix追加でも変換表層の末尾が書き換わります。このため従来の単純な共通prefix判定ではlatticeの再利用が中断され、同一入力状態を再評価する際にもCPU側の辞書探索を繰り返していました。

本変更では、入力・表層の対応が確定している直前の独立セグメント境界まで戻ってsuffixだけを再構築します。また、学習・ユーザ辞書・personalizationの影響がなく、入力と制約が完全一致する初回draftのみを共有します。

候補選択の意味を変えないよう、通常変換のN-bestは従来の2件を維持しています。

## 計測結果

M2 Pro / release / ZenzaiCPU、同条件5回平均です。

| ケース | ベースライン | 変更後 | 高速化 |
| --- | ---: | ---: | ---: |
| Roman2Kana 初回draft累計 | 1,092.9 ms | 252.1 ms | 4.33倍 |
| AZIK 初回draft累計 | 885.7 ms | 218.3 ms | 4.06倍 |
| `testGradualConversion_Roman2Kana` 全体 | 2.366 s | 1.428 s | 1.66倍 |
| `testGradualConversion_AZIK` 全体 | 1.921 s | 1.158 s | 1.66倍 |

同一実装でdraft cacheだけを無効化した比較では、cache単体でRoman全体を約20%、AZIK全体を約22%短縮しました。128件cacheによる追加peak memory footprintは約1.42 MiBです。

## 安全性

- cache keyに辞書identity、raw input、convert target、cursor、keyboard language、version config、prefix constraintを含める
- 学習、動的/永続ユーザ辞書、personalization、rich candidates利用時はcacheしない
- cacheするのは不変なpredecessor chainと先頭辞書nodeのみで、可変なlattice探索状態は共有しない
- Roman/AZIKの末尾書き換えについて、増分構築とfull rebuildの候補文字列・score一致をテスト

## 検証

- `testFullConversion`
- `testGradualConversion`
- `testGradualConversion_Roman2Kana`
- `testGradualConversion_AZIK`
- ZenzaiTests: 6件成功
- iOS 17 Simulator / release / ZenzaiCPU build成功
- 全182テスト中181件成功。残る`testMozcEvaluationData`は外部データ取得時のDNS失敗

Depends on #348
