### PR TITLE
perf(zenzai): 推論とincremental変換を最適化

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        # Swift 6.1.3 cannot import the Xcode 26 SDK currently selected by macos-latest.
+        # macos-15 uses Xcode 16.4, whose SDK is compatible with this toolchain.
+        os: [macos-15]
         # setup-swift on macOS currently rejects a 6.1 request when the runner resolves to 6.1.3.
         swift-version: ["6.1.3"]
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -144,9 +144,8 @@ let llamaCppTarget: Target = .systemLibrary(name: "llama.cpp")
 #else
 let llamaCppTarget: Target = .binaryTarget(
     name: "llama.cpp",
-    url: "https://github.com/azooKey/llama.cpp/releases/download/b4846/signed-llama.xcframework.zip",
-    // this can be computed `swift package compute-checksum llama-b4844-xcframework.zip`
-    checksum: "db3b13169df8870375f212e6ac21194225f1c85f7911d595ab64c8c790068e0a"
+    url: "https://github.com/azooKey/llama.cpp/releases/download/b9637-azookey.1/signed-llama-b9637-azookey.1.xcframework.zip",
+    checksum: "6176b3a6f7cbeca993644ca21d4b1c46ddaa59b98109376b7d32acef8e226a13"
 )
 #endif
 targets.append(llamaCppTarget)
@@ -165,7 +164,7 @@ targets.append(
 
 let package = Package(
     name: "AzooKeyKanaKanjiConverter",
-    platforms: [.iOS(.v16), .macOS(.v13)],
+    platforms: [.iOS(.v17), .macOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -4,7 +4,11 @@ import SwiftUtils
 
 extension Kana2Kanji {
     // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
-    private func computeMatchedAndTotalLength(prev: RegisteredNode?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
+    private func computeMatchedAndTotalLength(
+        prev: borrowing RegisteredNode?,
+        currentWord: borrowing String,
+        constraintBytes: borrowing [UInt8]
+    ) -> (matched: Int, total: Int) {
         let previousTotal = prev.map { Int($0.candidateUTF8Count) } ?? 0
         var matched = prev.map { Int($0.constraintMatchedUTF8Count) } ?? 0
         let total = previousTotal + currentWord.utf8.count
@@ -24,7 +28,11 @@ extension Kana2Kanji {
     }
 
     // Extend match with next word starting from current matched index
-    private func extendMatched(matched: Int, nextWord: String, constraintBytes: [UInt8]) -> (matched: Int, mismatch: Bool) {
+    private func extendMatched(
+        matched: Int,
+        nextWord: borrowing String,
+        constraintBytes: borrowing [UInt8]
+    ) -> (matched: Int, mismatch: Bool) {
         var ci = matched
         if ci >= constraintBytes.count {
             return (ci, false)
@@ -99,6 +107,9 @@ extension Kana2Kanji {
                 rawNodes: rawNodes
             )
         }
+        let constraintBytes = constraint.constraint
+        let constraintLength = constraintBytes.count
+        let enforcesConstraintOnStaticDictionary = !constraint.ignoreMemoryAndUserDictionary
         // 「i文字目から始まるnodes」に対して
         for (isHead, nodeArray) in lattice.indexedNodes(indices: latticeIndices) {
             // それぞれのnodeに対して
@@ -114,16 +125,13 @@ extension Kana2Kanji {
                             : 0
                     )
                     let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
-                    let constraintBytes = constraint.constraint
                     let matchState = self.computeMatchedAndTotalLength(
                         prev: previous,
                         currentWord: node.data.word,
                         constraintBytes: constraintBytes
                     )
-                    let constraintLength = constraintBytes.count
-
                     if nextIndex.surfaceIndex == surfaceCount {
-                        if !constraint.ignoreMemoryAndUserDictionary,
+                        if enforcesConstraintOnStaticDictionary,
                            node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let condition = if constraint.hasEOS {
                                 matchState.matched == constraintLength
@@ -157,7 +165,7 @@ extension Kana2Kanji {
                            current.totalValue >= newValue {
                             continue
                         }
-                        if !constraint.ignoreMemoryAndUserDictionary,
+                        if enforcesConstraintOnStaticDictionary,
                            nextNode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             guard matchState.matched
                                 == min(matchState.total, constraintLength) else {
@@ -208,22 +216,21 @@ extension Kana2Kanji {
                 // 変換した文字数
                 let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
                 // 文字数がcountと等しい場合登録する
-                let constraintBytes = constraint.constraint
                 if nextIndex.surfaceIndex == surfaceCount {
                     // Precompute matched/total lengths per prev for (prev + current word)
                     let mtPerPrev: [(matched: Int, total: Int)] = node.prevs.indices.map { idx in
                         self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
                     }
-                    let cLen = constraintBytes.count
                     for index in node.prevs.indices {
                         // 学習データやユーザ辞書由来の場合は素通しする
-                        if !constraint.ignoreMemoryAndUserDictionary, node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                        if enforcesConstraintOnStaticDictionary,
+                           node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let (matched, total) = mtPerPrev[index]
                             // 最終チェック（EOS時の条件に合わせる）
                             let condition = if constraint.hasEOS {
-                                matched == cLen && total == cLen
+                                matched == constraintLength && total == constraintLength
                             } else {
-                                matched == cLen
+                                matched == constraintLength
                             }
                             guard condition else {
                                 continue
@@ -251,7 +258,6 @@ extension Kana2Kanji {
                     let mtPerPrev: [(matched: Int, total: Int)] = node.prevs.indices.map { idx in
                         self.computeMatchedAndTotalLength(prev: node.prevs[idx], currentWord: node.data.word, constraintBytes: constraintBytes)
                     }
-                    let cLen = constraintBytes.count
                     let ccLatter = self.dicdataStore.getCCLatter(node.data.rcid)
                     // nodeの繋がる次にあり得る全てのnextnodeに対して
                     for nextnode in lattice[index: nextIndex] {
@@ -271,10 +277,11 @@ extension Kana2Kanji {
                             // 制約 AB 単語 A   (OK)
                             // 制約 AB 単語 AC  (NG)
                             // ただし、学習データやユーザ辞書由来の場合は素通しする
-                            if !constraint.ignoreMemoryAndUserDictionary, nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            if enforcesConstraintOnStaticDictionary,
+                               nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                                 let (matchedPrev, totalPrev) = mtPerPrev[index]
                                 // ensure no prior mismatch
-                                guard matchedPrev == min(totalPrev, cLen) else {
+                                guard matchedPrev == min(totalPrev, constraintLength) else {
                                     continue
                                 }
                                 let nextLen = nextnode.data.word.utf8.count
@@ -286,10 +293,11 @@ extension Kana2Kanji {
                                 let newTotal = totalPrev + nextLen
                                 let ok: Bool = if constraint.hasEOS {
                                     // require strict prefix of constraint
-                                    matchedExt == newTotal && newTotal < cLen
+                                    matchedExt == newTotal && newTotal < constraintLength
                                 } else {
                                     // accept either: constraint is prefix of candidate, or candidate is prefix of constraint
-                                    (matchedExt == cLen) || (newTotal <= cLen && matchedExt == newTotal)
+                                    (matchedExt == constraintLength)
+                                        || (newTotal <= constraintLength && matchedExt == newTotal)
                                 }
                                 guard ok else {
                                     continue
@@ -320,8 +328,8 @@ extension Kana2Kanji {
         inputCount: Int,
         surfaceCount: Int,
         incrementalCacheInfo: (inputData: ComposingText, lattice: Lattice)?,
-        dicdataStoreState: DicdataStoreState,
-        ) -> Lattice {
+        dicdataStoreState: DicdataStoreState
+    ) -> Lattice {
         let indexMap = LatticeDualIndexMap(inputData)
         let latticeIndices = indexMap.indices(inputCount: inputCount, surfaceCount: surfaceCount)
         guard let incrementalCacheInfo else {
@@ -362,9 +370,11 @@ extension Kana2Kanji {
         let commonInputCount = zip(oldInput, newInput).prefix { $0 == $1 }.count
         let commonSurfaceCount = zip(oldSurface, newSurface).prefix { $0 == $1 }.count
 
-        // 逐次入力でない場合（中間の文字が変わった場合）は通常の処理
-        if commonInputCount != min(oldInput.count, newInput.count) ||
-            commonSurfaceCount != min(oldSurface.count, newSurface.count) {
+        // inputの中間が変更された場合は通常の処理に戻す。
+        // Roman/AZIKの逐次入力では、inputは単純なsuffix追加でも
+        // convertTargetの未確定suffixが `k -> か` のように書き換わる。
+        // そのケースは下で独立セグメント境界まで戻し、suffixだけ作り直す。
+        if commonInputCount != oldInput.count {
             let rawNodes = latticeIndices.map { index in
                 let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex {
                     (iIndex, nil)
@@ -394,15 +404,38 @@ extension Kana2Kanji {
         // 逐次入力の場合：既存Latticeから共通部分を再利用し、新しい部分のみ辞書引き
         let cachedLattice = incrementalCacheInfo.lattice
 
+        // surfaceの末尾書き換えがある場合、commonSurfaceCountがローマ字変換の
+        // 独立セグメント内を指すことがある。その位置ではinput/surfaceの
+        // 対応が一意でないため、直前の独立セグメント境界まで戻す。
+        let reusableBoundary: (input: Int, surface: Int)
+        if commonSurfaceCount == oldSurface.count {
+            reusableBoundary = (commonInputCount, commonSurfaceCount)
+        } else {
+            reusableBoundary = incrementalCacheInfo.inputData
+                .inputIndexToSurfaceIndexMap()
+                .lazy
+                .filter { $0.value <= commonSurfaceCount }
+                .map { (input: $0.key, surface: $0.value) }
+                .max {
+                    if $0.surface == $1.surface {
+                        $0.input < $1.input
+                    } else {
+                        $0.surface < $1.surface
+                    }
+                } ?? (0, 0)
+        }
+        let reusableInputCount = reusableBoundary.input
+        let reusableSurfaceCount = reusableBoundary.surface
+
         // 純粋なsuffix追加では既存Latticeの全ノードがそのまま有効なので、
         // 各ノード配列のfilterと再構築を避ける。削除を伴う場合だけprefixを切り出す。
-        var newLattice = if commonInputCount == oldInput.count,
-                            commonSurfaceCount == oldSurface.count {
+        var newLattice = if reusableInputCount == oldInput.count,
+                            reusableSurfaceCount == oldSurface.count {
             cachedLattice
         } else {
             cachedLattice.prefix(
-                inputCount: commonInputCount,
-                surfaceCount: commonSurfaceCount
+                inputCount: reusableInputCount,
+                surfaceCount: reusableSurfaceCount
             )
         }
         newLattice.resetNodeStates()
@@ -412,24 +445,24 @@ extension Kana2Kanji {
         // 始まるノードは新規suffixへ到達できない。
         let earliestAffectedInputIndex = max(
             0,
-            commonInputCount + 1 - self.dicdataStore.maxlength
+            reusableInputCount + 1 - self.dicdataStore.maxlength
         )
         let earliestAffectedSurfaceIndex = max(
             0,
-            commonSurfaceCount + 1 - self.dicdataStore.maxlength
+            reusableSurfaceCount + 1 - self.dicdataStore.maxlength
         )
         let additionalRawNodes = latticeIndices.map { index in
             let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex,
                                                                               iIndex >= earliestAffectedInputIndex,
-                                                                              max(commonInputCount, iIndex) < inputCount {
-                (iIndex, max(commonInputCount, iIndex) ..< inputCount)
+                                                                              max(reusableInputCount, iIndex) < inputCount {
+                (iIndex, max(reusableInputCount, iIndex) ..< inputCount)
             } else {
                 nil
             }
             let surfaceRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let sIndex = index.surfaceIndex,
                                                                                 sIndex >= earliestAffectedSurfaceIndex,
-                                                                                max(commonSurfaceCount, sIndex) < surfaceCount {
-                (sIndex, max(commonSurfaceCount, sIndex) ..< surfaceCount)
+                                                                                max(reusableSurfaceCount, sIndex) < surfaceCount {
+                (sIndex, max(reusableSurfaceCount, sIndex) ..< surfaceCount)
             } else {
                 nil
             }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -5,41 +5,22 @@ import SwiftUtils
 extension Kana2Kanji {
     // Compute matched bytes with constraint and total candidate bytes for (prev-chain + currentWord)
     private func computeMatchedAndTotalLength(prev: RegisteredNode?, currentWord: String, constraintBytes: [UInt8]) -> (matched: Int, total: Int) {
-        // collect words from prev chain in forward order
-        var words: [String] = []
-        var p = prev
-        while let node = p {
-            if !node.data.word.isEmpty {
-                words.append(node.data.word)
-            }
-            p = node.prev
-        }
-        words.reverse()
-        words.append(currentWord)
+        let previousTotal = prev.map { Int($0.candidateUTF8Count) } ?? 0
+        var matched = prev.map { Int($0.constraintMatchedUTF8Count) } ?? 0
+        let total = previousTotal + currentWord.utf8.count
 
-        // total = sum of utf8 counts (cheap per word)
-        let total = words.reduce(0) { $0 + $1.utf8.count }
-
-        // matched = compare up to first mismatch or until constraint end
-        var ci = 0
-        if !constraintBytes.isEmpty {
-            outer: for w in words {
-                if ci >= constraintBytes.count {
-                    break
-                }
-                for b in w.utf8 {
-                    if ci >= constraintBytes.count {
-                        break outer
-                    }
-                    if b != constraintBytes[ci] {
-                        break outer
-                    }
-                    ci += 1
-                }
-            }
+        // 直前までに不一致がなければ、今回追加する単語だけを照合する。
+        // RegisteredNode生成時に累積値を保持するため、経路全体の再走査は不要。
+        guard matched == min(previousTotal, constraintBytes.count) else {
+            return (matched, total)
         }
-        // このprevのutf8カウントはtotalで、そのうちconstraintBytesと一致する部分がci
-        return (matched: ci, total: total)
+        for byte in currentWord.utf8 {
+            guard matched < constraintBytes.count, byte == constraintBytes[matched] else {
+                break
+            }
+            matched += 1
+        }
+        return (matched, total)
     }
 
     // Extend match with next word starting from current matched index
@@ -125,6 +106,96 @@ extension Kana2Kanji {
                 if node.prevs.isEmpty {
                     continue
                 }
+                if N_best == 1, let previous = node.prevs.first {
+                    let wValue = node.data.value()
+                    let value = previous.totalValue + wValue + (
+                        isHead
+                            ? self.dicdataStore.getCCValue(previous.data.rcid, node.data.lcid)
+                            : 0
+                    )
+                    let nextIndex = indexMap.dualIndex(for: node.range.endIndex)
+                    let constraintBytes = constraint.constraint
+                    let matchState = self.computeMatchedAndTotalLength(
+                        prev: previous,
+                        currentWord: node.data.word,
+                        constraintBytes: constraintBytes
+                    )
+                    let constraintLength = constraintBytes.count
+
+                    if nextIndex.surfaceIndex == surfaceCount {
+                        if !constraint.ignoreMemoryAndUserDictionary,
+                           node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            let condition = if constraint.hasEOS {
+                                matchState.matched == constraintLength
+                                    && matchState.total == constraintLength
+                            } else {
+                                matchState.matched == constraintLength
+                            }
+                            guard condition else {
+                                continue
+                            }
+                        }
+                        let newNode = node.getRegisteredNode(
+                            0,
+                            value: value,
+                            constraintState: matchState
+                        )
+                        if let current = result.prevs.first {
+                            if newNode.totalValue > current.totalValue {
+                                result.prevs[0] = newNode
+                            }
+                        } else {
+                            result.prevs.append(newNode)
+                        }
+                        continue
+                    }
+
+                    let ccLatter = self.dicdataStore.getCCLatter(node.data.rcid)
+                    for nextNode in lattice[index: nextIndex] {
+                        let newValue = value + ccLatter.get(nextNode.data.lcid)
+                        if let current = nextNode.prevs.first,
+                           current.totalValue >= newValue {
+                            continue
+                        }
+                        if !constraint.ignoreMemoryAndUserDictionary,
+                           nextNode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            guard matchState.matched
+                                == min(matchState.total, constraintLength) else {
+                                continue
+                            }
+                            let nextLength = nextNode.data.word.utf8.count
+                            let (matched, mismatch) = self.extendMatched(
+                                matched: matchState.matched,
+                                nextWord: nextNode.data.word,
+                                constraintBytes: constraintBytes
+                            )
+                            if mismatch {
+                                continue
+                            }
+                            let newTotal = matchState.total + nextLength
+                            let isCompatible = if constraint.hasEOS {
+                                matched == newTotal && newTotal < constraintLength
+                            } else {
+                                matched == constraintLength
+                                    || (newTotal <= constraintLength && matched == newTotal)
+                            }
+                            guard isCompatible else {
+                                continue
+                            }
+                        }
+                        let newNode = node.getRegisteredNode(
+                            0,
+                            value: newValue,
+                            constraintState: matchState
+                        )
+                        if nextNode.prevs.isEmpty {
+                            nextNode.prevs.append(newNode)
+                        } else {
+                            nextNode.prevs[0] = newNode
+                        }
+                    }
+                    continue
+                }
                 // 生起確率を取得する。
                 let wValue: PValue = node.data.value()
                 if isHead {
@@ -158,8 +229,22 @@ extension Kana2Kanji {
                                 continue
                             }
                         }
-                        let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
-                        result.prevs.append(newnode)
+                        let newnode: RegisteredNode = node.getRegisteredNode(
+                            index,
+                            value: node.values[index],
+                            constraintState: mtPerPrev[index]
+                        )
+                        if N_best == 1 {
+                            if let current = result.prevs.first {
+                                if newnode.totalValue > current.totalValue {
+                                    result.prevs[0] = newnode
+                                }
+                            } else {
+                                result.prevs.append(newnode)
+                            }
+                        } else {
+                            result.prevs.append(newnode)
+                        }
                     }
                 } else {
                     // Precompute matched/total lengths per prev for (prev + current word)
@@ -214,7 +299,11 @@ extension Kana2Kanji {
                             if nextnode.prevs.count >= N_best {
                                 nextnode.prevs.removeLast()
                             }
-                            let newnode: RegisteredNode = node.getRegisteredNode(index, value: newValue)
+                            let newnode: RegisteredNode = node.getRegisteredNode(
+                                index,
+                                value: newValue,
+                                constraintState: mtPerPrev[index]
+                            )
                             // removeしてからinsertした方が速い (insertはO(N)なので)
                             nextnode.prevs.insert(newnode, at: lastindex)
                         }
@@ -305,18 +394,41 @@ extension Kana2Kanji {
         // 逐次入力の場合：既存Latticeから共通部分を再利用し、新しい部分のみ辞書引き
         let cachedLattice = incrementalCacheInfo.lattice
 
-        // 共通部分のLatticeを取得（SuffixReplacementProcessing.swiftのprefixメソッドを想定）
-        var newLattice = cachedLattice.prefix(inputCount: commonInputCount, surfaceCount: commonSurfaceCount)
+        // 純粋なsuffix追加では既存Latticeの全ノードがそのまま有効なので、
+        // 各ノード配列のfilterと再構築を避ける。削除を伴う場合だけprefixを切り出す。
+        var newLattice = if commonInputCount == oldInput.count,
+                            commonSurfaceCount == oldSurface.count {
+            cachedLattice
+        } else {
+            cachedLattice.prefix(
+                inputCount: commonInputCount,
+                surfaceCount: commonSurfaceCount
+            )
+        }
         newLattice.resetNodeStates()
 
         // 新規部分に関わる辞書引き（既存部分から新規部分にまたがる単語も含む）
+        // lookupDicdata自体がmaxlengthより長い範囲を探索しないため、それより前から
+        // 始まるノードは新規suffixへ到達できない。
+        let earliestAffectedInputIndex = max(
+            0,
+            commonInputCount + 1 - self.dicdataStore.maxlength
+        )
+        let earliestAffectedSurfaceIndex = max(
+            0,
+            commonSurfaceCount + 1 - self.dicdataStore.maxlength
+        )
         let additionalRawNodes = latticeIndices.map { index in
-            let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex, max(commonInputCount, iIndex) < inputCount {
+            let inputRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let iIndex = index.inputIndex,
+                                                                              iIndex >= earliestAffectedInputIndex,
+                                                                              max(commonInputCount, iIndex) < inputCount {
                 (iIndex, max(commonInputCount, iIndex) ..< inputCount)
             } else {
                 nil
             }
-            let surfaceRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let sIndex = index.surfaceIndex, max(commonSurfaceCount, sIndex) < surfaceCount {
+            let surfaceRange: (startIndex: Int, endIndexRange: Range<Int>?)? = if let sIndex = index.surfaceIndex,
+                                                                                sIndex >= earliestAffectedSurfaceIndex,
+                                                                                max(commonSurfaceCount, sIndex) < surfaceCount {
                 (sIndex, max(commonSurfaceCount, sIndex) ..< surfaceCount)
             } else {
                 nil

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Lattice.swift
@@ -14,8 +14,23 @@ struct LatticeNodeArray: Sequence {
 
 struct LatticeDualIndexMap: Sendable {
     private var inputIndexToSurfaceIndexMap: [Int: Int]
+    private var surfaceIndexToInputIndexMap: [Int: Int]
+    private var isIdentity: Bool
+
     init(_ composingText: ComposingText) {
-        self.inputIndexToSurfaceIndexMap = composingText.inputIndexToSurfaceIndexMap()
+        if composingText.hasIdentityInputSurfaceIndexMapping {
+            self.inputIndexToSurfaceIndexMap = [:]
+            self.surfaceIndexToInputIndexMap = [:]
+            self.isIdentity = true
+            return
+        }
+        let inputToSurface = composingText.inputIndexToSurfaceIndexMap()
+        self.inputIndexToSurfaceIndexMap = inputToSurface
+        self.surfaceIndexToInputIndexMap = Dictionary(
+            inputToSurface.map { ($0.value, $0.key) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        self.isIdentity = false
     }
 
     enum DualIndex: Sendable, Equatable, Hashable {
@@ -43,7 +58,13 @@ struct LatticeDualIndexMap: Sendable {
     }
 
     func dualIndex(for latticeIndex: Lattice.LatticeIndex) -> DualIndex {
-        switch latticeIndex {
+        if self.isIdentity {
+            return switch latticeIndex {
+            case .input(let index), .surface(let index):
+                .bothIndex(inputIndex: index, surfaceIndex: index)
+            }
+        }
+        return switch latticeIndex {
         case .input(let iIndex):
             if let sIndex = self.inputIndexToSurfaceIndexMap[iIndex] {
                 .bothIndex(inputIndex: iIndex, surfaceIndex: sIndex)
@@ -51,7 +72,7 @@ struct LatticeDualIndexMap: Sendable {
                 .inputIndex(iIndex)
             }
         case .surface(let sIndex):
-            if let iIndex = self.inputIndexToSurfaceIndexMap.filter({ $0.value == sIndex}).first?.key {
+            if let iIndex = self.surfaceIndexToInputIndexMap[sIndex] {
                 .bothIndex(inputIndex: iIndex, surfaceIndex: sIndex)
             } else {
                 .surfaceIndex(sIndex)
@@ -60,6 +81,11 @@ struct LatticeDualIndexMap: Sendable {
     }
 
     func indices(inputCount: Int, surfaceCount: Int) -> [DualIndex] {
+        if self.isIdentity {
+            return (0 ..< min(inputCount, surfaceCount)).map {
+                .bothIndex(inputIndex: $0, surfaceIndex: $0)
+            }
+        }
         var indices: [DualIndex] = []
         var sIndexPointer = 0
         for i in 0 ..< inputCount {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
@@ -37,7 +37,11 @@ public final class LatticeNode {
 
     /// `LatticeNode`の持っている情報を反映した`RegisteredNode`を作成する
     /// `LatticeNode`は複数の過去のノードを持つことができるが、`RegisteredNode`は1つしか持たない。
-    func getRegisteredNode(_ index: Int, value: PValue) -> RegisteredNode {
+    func getRegisteredNode(
+        _ index: Int,
+        value: PValue,
+        constraintState: (matched: Int, total: Int)? = nil
+    ) -> RegisteredNode {
         let payload: RegisteredNodePayload
         if let registeredNodePayload {
             payload = registeredNodePayload
@@ -45,7 +49,12 @@ public final class LatticeNode {
             payload = RegisteredNodePayload(data: self.data, range: self.range)
             self.registeredNodePayload = payload
         }
-        return RegisteredNode(payload: payload, registered: self.prevs[index], totalValue: value)
+        return RegisteredNode(
+            payload: payload,
+            registered: self.prevs[index],
+            totalValue: value,
+            constraintState: constraintState
+        )
     }
 
     /// 再帰的にノードを遡り、`CandidateData`を構築する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/LatticeNode.swift
@@ -17,7 +17,12 @@ public final class LatticeNode {
     /// `prevs`の各要素に対応するスコアのデータ
     var values: [PValue] = []
     /// inputData.input内のrange
-    var range: Lattice.LatticeRange
+    var range: Lattice.LatticeRange {
+        didSet {
+            self.registeredNodePayload = nil
+        }
+    }
+    private var registeredNodePayload: RegisteredNodePayload?
 
     /// `EOS`に対応するノード。
     static var EOSNode: LatticeNode {
@@ -33,7 +38,14 @@ public final class LatticeNode {
     /// `LatticeNode`の持っている情報を反映した`RegisteredNode`を作成する
     /// `LatticeNode`は複数の過去のノードを持つことができるが、`RegisteredNode`は1つしか持たない。
     func getRegisteredNode(_ index: Int, value: PValue) -> RegisteredNode {
-        RegisteredNode(data: self.data, registered: self.prevs[index], totalValue: value, range: self.range)
+        let payload: RegisteredNodePayload
+        if let registeredNodePayload {
+            payload = registeredNodePayload
+        } else {
+            payload = RegisteredNodePayload(data: self.data, range: self.range)
+            self.registeredNodePayload = payload
+        }
+        return RegisteredNode(payload: payload, registered: self.prevs[index], totalValue: value)
     }
 
     /// 再帰的にノードを遡り、`CandidateData`を構築する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
@@ -1,15 +1,27 @@
 import Foundation
 
-/// `indirect enum`を用いて再帰的なノード構造を実現
+/// N-bestの複数経路で共通する辞書データと入力範囲を1回だけ保持する。
+final class RegisteredNodePayload {
+    init(data: consuming DicdataElement, range: Lattice.LatticeRange) {
+        self.data = data
+        self.range = range
+    }
+
+    let data: DicdataElement
+    let range: Lattice.LatticeRange
+}
+
+/// `indirect enum`を用いて再帰的なノード構造を実現する。
+/// 辞書データと入力範囲は、同じLatticeNodeから派生したN-best経路間で共有する。
 indirect enum RegisteredNode {
-    case node(data: DicdataElement, prev: RegisteredNode?, totalValue: PValue, range: Lattice.LatticeRange)
+    case node(payload: RegisteredNodePayload, prev: RegisteredNode?, totalValue: PValue)
 
     /// このノードが保持する辞書データ
     var data: DicdataElement {
         _read {
             switch self {
-            case .node(let data, _, _, _):
-                yield data
+            case .node(let payload, _, _):
+                yield payload.data
             }
         }
     }
@@ -18,7 +30,7 @@ indirect enum RegisteredNode {
     var prev: RegisteredNode? {
         _read {
             switch self {
-            case .node(_, let prev, _, _):
+            case .node(_, let prev, _):
                 yield prev
             }
         }
@@ -27,7 +39,7 @@ indirect enum RegisteredNode {
     /// 始点からこのノードまでのコスト
     var totalValue: PValue {
         switch self {
-        case .node(_, _, let totalValue, _):
+        case .node(_, _, let totalValue):
             return totalValue
         }
     }
@@ -35,13 +47,21 @@ indirect enum RegisteredNode {
     /// `composingText`の`input`で対応する範囲
     var range: Lattice.LatticeRange {
         switch self {
-        case .node(_, _, _, let range):
-            return range
+        case .node(let payload, _, _):
+            return payload.range
         }
     }
 
     init(data: DicdataElement, registered: RegisteredNode?, totalValue: PValue, range: Lattice.LatticeRange) {
-        self = .node(data: data, prev: registered, totalValue: totalValue, range: range)
+        self = .node(
+            payload: RegisteredNodePayload(data: data, range: range),
+            prev: registered,
+            totalValue: totalValue
+        )
+    }
+
+    init(payload: RegisteredNodePayload, registered: RegisteredNode?, totalValue: PValue) {
+        self = .node(payload: payload, prev: registered, totalValue: totalValue)
     }
 
     /// 始点ノードを生成する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/RegisteredNode.swift
@@ -14,13 +14,19 @@ final class RegisteredNodePayload {
 /// `indirect enum`を用いて再帰的なノード構造を実現する。
 /// 辞書データと入力範囲は、同じLatticeNodeから派生したN-best経路間で共有する。
 indirect enum RegisteredNode {
-    case node(payload: RegisteredNodePayload, prev: RegisteredNode?, totalValue: PValue)
+    case node(
+        payload: RegisteredNodePayload,
+        prev: RegisteredNode?,
+        totalValue: PValue,
+        candidateUTF8Count: UInt16,
+        constraintMatchedUTF8Count: UInt16
+    )
 
     /// このノードが保持する辞書データ
     var data: DicdataElement {
         _read {
             switch self {
-            case .node(let payload, _, _):
+            case .node(let payload, _, _, _, _):
                 yield payload.data
             }
         }
@@ -30,7 +36,7 @@ indirect enum RegisteredNode {
     var prev: RegisteredNode? {
         _read {
             switch self {
-            case .node(_, let prev, _):
+            case .node(_, let prev, _, _, _):
                 yield prev
             }
         }
@@ -39,29 +45,59 @@ indirect enum RegisteredNode {
     /// 始点からこのノードまでのコスト
     var totalValue: PValue {
         switch self {
-        case .node(_, _, let totalValue):
+        case .node(_, _, let totalValue, _, _):
             return totalValue
+        }
+    }
+
+    var candidateUTF8Count: UInt16 {
+        switch self {
+        case .node(_, _, _, let candidateUTF8Count, _):
+            return candidateUTF8Count
+        }
+    }
+
+    var constraintMatchedUTF8Count: UInt16 {
+        switch self {
+        case .node(_, _, _, _, let constraintMatchedUTF8Count):
+            return constraintMatchedUTF8Count
         }
     }
 
     /// `composingText`の`input`で対応する範囲
     var range: Lattice.LatticeRange {
         switch self {
-        case .node(let payload, _, _):
+        case .node(let payload, _, _, _, _):
             return payload.range
         }
     }
 
     init(data: DicdataElement, registered: RegisteredNode?, totalValue: PValue, range: Lattice.LatticeRange) {
+        let candidateUTF8Count = (registered.map { Int($0.candidateUTF8Count) } ?? 0) + data.word.utf8.count
         self = .node(
             payload: RegisteredNodePayload(data: data, range: range),
             prev: registered,
-            totalValue: totalValue
+            totalValue: totalValue,
+            candidateUTF8Count: UInt16(clamping: candidateUTF8Count),
+            constraintMatchedUTF8Count: 0
         )
     }
 
-    init(payload: RegisteredNodePayload, registered: RegisteredNode?, totalValue: PValue) {
-        self = .node(payload: payload, prev: registered, totalValue: totalValue)
+    init(
+        payload: RegisteredNodePayload,
+        registered: RegisteredNode?,
+        totalValue: PValue,
+        constraintState: (matched: Int, total: Int)? = nil
+    ) {
+        let candidateUTF8Count = constraintState?.total
+            ?? ((registered.map { Int($0.candidateUTF8Count) } ?? 0) + payload.data.word.utf8.count)
+        self = .node(
+            payload: payload,
+            prev: registered,
+            totalValue: totalValue,
+            candidateUTF8Count: UInt16(clamping: candidateUTF8Count),
+            constraintMatchedUTF8Count: UInt16(clamping: constraintState?.matched ?? 0)
+        )
     }
 
     /// 始点ノードを生成する関数

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -64,27 +64,6 @@ package final class Zenz {
         // 不一致範囲を除去するため、Converter単位のnative context再生成は不要。
     }
 
-    func cachedResolvedConversion(
-        for key: ZenzResolvedConversionCacheKey
-    ) -> ZenzResolvedConversion? {
-        self.zenzContext?.cachedResolvedConversion(for: key)
-    }
-
-    func cacheResolvedConversion(
-        _ value: ZenzResolvedConversion,
-        for key: ZenzResolvedConversionCacheKey
-    ) {
-        self.zenzContext?.cacheResolvedConversion(value, for: key)
-    }
-
-    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
-        self.zenzContext?.cachedDraftConversion(for: key)
-    }
-
-    func cacheDraftConversion(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
-        self.zenzContext?.cacheDraftConversion(value, for: key)
-    }
-
     func candidateEvaluate(
         convertTarget: String,
         convertTargetCursorPosition: Int? = nil,
@@ -92,7 +71,8 @@ package final class Zenz {
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
-        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
+        sessionCache: ZenzaiSessionCache
     ) -> CandidateEvaluationResult {
         self.inferenceLock.withLock {
             guard let zenzContext else {
@@ -107,7 +87,8 @@ package final class Zenz {
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: prefixConstraint,
                     personalizationMode: personalizationMode,
-                    versionDependentConfig: versionDependentConfig
+                    versionDependentConfig: versionDependentConfig,
+                    sessionCache: sessionCache
                 )
             }
             return .error

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -77,6 +77,14 @@ package final class Zenz {
         self.zenzContext?.cacheResolvedConversion(value, for: key)
     }
 
+    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.zenzContext?.cachedDraftConversion(for: key)
+    }
+
+    func cacheDraftConversion(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
+        self.zenzContext?.cacheDraftConversion(value, for: key)
+    }
+
     func candidateEvaluate(
         convertTarget: String,
         convertTargetCursorPosition: Int? = nil,

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -2,9 +2,43 @@ import EfficientNGram
 package import Foundation
 import SwiftUtils
 
+/// 同一モデルのnative contextをConverter間で共有する。
+///
+/// CPU推論を直列化することで、複数Converterが同時に18 MiBのKV cacheを保持する
+/// ことを避ける。context内のKV再利用は毎回完全なtoken prefixを照合するため、
+/// セッションを跨いでも推論結果には影響しない。
+private final class SharedZenzCache: @unchecked Sendable {
+    static let shared = SharedZenzCache()
+
+    private init() {
+        self.cache.countLimit = 1
+    }
+
+    func zenz(resourceURL: URL) throws -> Zenz {
+        try self.lock.withLock {
+            let key = resourceURL.absoluteString as NSString
+            if let cached = self.cache.object(forKey: key) {
+                return cached
+            }
+            let zenz = try Zenz(resourceURL: resourceURL)
+            self.cache.setObject(zenz, forKey: key)
+            return zenz
+        }
+    }
+
+    private let cache = NSCache<NSString, Zenz>()
+    private let lock = NSLock()
+}
+
 package final class Zenz {
     package var resourceURL: URL
     private var zenzContext: ZenzContext?
+    private let inferenceLock = NSLock()
+
+    package static func shared(resourceURL: URL) throws -> Zenz {
+        try SharedZenzCache.shared.zenz(resourceURL: resourceURL)
+    }
+
     init(resourceURL: URL) throws {
         self.resourceURL = resourceURL
         do {
@@ -26,7 +60,21 @@ package final class Zenz {
     }
 
     package func endSession() {
-        try? self.zenzContext?.resetContext()
+        // contextはモデル単位で共有される。各呼び出し時にtoken prefixを照合して
+        // 不一致範囲を除去するため、Converter単位のnative context再生成は不要。
+    }
+
+    func cachedResolvedConversion(
+        for key: ZenzResolvedConversionCacheKey
+    ) -> ZenzResolvedConversion? {
+        self.zenzContext?.cachedResolvedConversion(for: key)
+    }
+
+    func cacheResolvedConversion(
+        _ value: ZenzResolvedConversion,
+        for key: ZenzResolvedConversionCacheKey
+    ) {
+        self.zenzContext?.cacheResolvedConversion(value, for: key)
     }
 
     func candidateEvaluate(
@@ -35,25 +83,29 @@ package final class Zenz {
         candidates: [Candidate],
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
+        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
-        guard let zenzContext else {
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return .error
+            }
+            for candidate in candidates {
+                return ZenzCandidateEvaluator.evaluate(
+                    context: zenzContext,
+                    input: convertTarget.toKatakana(),
+                    inputCursorPosition: convertTargetCursorPosition,
+                    candidate: candidate,
+                    requestRichCandidates: requestRichCandidates,
+                    prefixConstraint: prefixConstraint,
+                    incrementalPrefixConstraint: incrementalPrefixConstraint,
+                    personalizationMode: personalizationMode,
+                    versionDependentConfig: versionDependentConfig
+                )
+            }
             return .error
         }
-        for candidate in candidates {
-            return ZenzCandidateEvaluator.evaluate(
-                context: zenzContext,
-                input: convertTarget.toKatakana(),
-                inputCursorPosition: convertTargetCursorPosition,
-                candidate: candidate,
-                requestRichCandidates: requestRichCandidates,
-                prefixConstraint: prefixConstraint,
-                personalizationMode: personalizationMode,
-                versionDependentConfig: versionDependentConfig
-            )
-        }
-        return .error
     }
 
     func predictNextInputText(
@@ -65,26 +117,34 @@ package final class Zenz {
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
         possibleNexts: [String] = []
     ) -> String {
-        guard let zenzContext else {
-            return ""
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return ""
+            }
+            return ZenzInputTextGenerator.generate(
+                context: zenzContext,
+                leftSideContext: leftSideContext,
+                composingText: composingText,
+                count: count,
+                minLength: minLength,
+                maxEntropy: maxEntropy,
+                versionDependentConfig: versionDependentConfig,
+                possibleNexts: possibleNexts
+            )
         }
-        return ZenzInputTextGenerator.generate(
-            context: zenzContext,
-            leftSideContext: leftSideContext,
-            composingText: composingText,
-            count: count,
-            minLength: minLength,
-            maxEntropy: maxEntropy,
-            versionDependentConfig: versionDependentConfig,
-            possibleNexts: possibleNexts
-        )
     }
 
     package func pureGreedyDecoding(pureInput: String, maxCount: Int = .max) -> String {
-        guard let zenzContext else {
-            return ""
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return ""
+            }
+            return ZenzPureGreedyDecoder.decode(
+                context: zenzContext,
+                leftSideContext: pureInput,
+                maxCount: maxCount
+            )
         }
-        return ZenzPureGreedyDecoder.decode(context: zenzContext, leftSideContext: pureInput, maxCount: maxCount)
     }
 
     func generateTypoCandidates(
@@ -94,16 +154,18 @@ package final class Zenz {
         experimentalConfig: ExperimentalTypoCorrectionConfig,
         cache: ZenzaiTypoGenerationCache
     ) -> [ZenzaiTypoCandidate] {
-        guard let zenzContext else {
-            return []
+        self.inferenceLock.withLock {
+            guard let zenzContext else {
+                return []
+            }
+            return ZenzaiTypoCandidateGenerator.generate(
+                context: zenzContext,
+                leftSideContext: leftSideContext,
+                composingText: composingText,
+                inputStyle: inputStyle,
+                experimentalConfig: experimentalConfig,
+                cache: cache
+            )
         }
-        return ZenzaiTypoCandidateGenerator.generate(
-            context: zenzContext,
-            leftSideContext: leftSideContext,
-            composingText: composingText,
-            inputStyle: inputStyle,
-            experimentalConfig: experimentalConfig,
-            cache: cache
-        )
     }
 }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -83,7 +83,6 @@ package final class Zenz {
         candidates: [Candidate],
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
-        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
@@ -99,7 +98,6 @@ package final class Zenz {
                     candidate: candidate,
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: prefixConstraint,
-                    incrementalPrefixConstraint: incrementalPrefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig
                 )

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -86,7 +86,8 @@ struct ZenzCandidateEvaluator {
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
-        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
+        sessionCache: ZenzaiSessionCache
     ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
         var userDictionaryPrompt = ""
@@ -132,17 +133,17 @@ struct ZenzCandidateEvaluator {
         } else {
             nil
         }
-        if let cacheKey, let cached = context.cachedEvaluation(for: cacheKey) {
+        if let cacheKey, let cached = sessionCache.cachedEvaluation(for: cacheKey) {
             return cached
         }
         func finish(_ result: CandidateEvaluationResult) -> CandidateEvaluationResult {
             if let cacheKey, result != .error {
-                context.cacheEvaluation(result, for: cacheKey)
+                sessionCache.cacheEvaluation(result, for: cacheKey)
             }
             return result
         }
 
-        let promptTokens = context.encodeEvaluationPrompt(prompt)
+        let promptTokens = context.encodeEvaluationPrompt(prompt, sessionCache: sessionCache)
         let candidateTokens = context.encode(candidateTextForEvaluation, addBOS: false, addEOS: false)
         let addressedTokens: [llama_token]
         if reusesAddressedPrefix {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -78,14 +78,6 @@ final class ZenzEvaluationCache: @unchecked Sendable {
 }
 
 struct ZenzCandidateEvaluator {
-    private struct IncrementalEvaluationProjection {
-        var stableCandidatePrefix: String
-        var input: String
-        var candidateText: String
-        var remainingConstraint: [UInt8]
-        var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
-    }
-
     static func evaluate(
         context: ZenzContext,
         input: String,
@@ -93,36 +85,25 @@ struct ZenzCandidateEvaluator {
         candidate: Candidate,
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
-        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
-        let projection = self.incrementalEvaluationProjection(
-            input: input,
-            inputCursorPosition: inputCursorPosition,
-            candidate: candidate,
-            requestRichCandidates: requestRichCandidates,
-            prefixConstraint: prefixConstraint,
-            incrementalPrefixConstraint: incrementalPrefixConstraint,
-            personalizationMode: personalizationMode,
-            versionDependentConfig: versionDependentConfig
-        )
         var userDictionaryPrompt = ""
         for item in candidate.data where item.metadata.contains(.isFromUserDictionary) {
             userDictionaryPrompt += "\(item.word)(\(item.ruby.toHiragana()))"
         }
         let prompt = ZenzPromptBuilder.candidateEvaluationPrompt(
-            input: projection.input,
+            input: input,
             inputCursorPosition: inputCursorPosition,
             userDictionaryPrompt: userDictionaryPrompt,
-            versionDependentConfig: projection.versionDependentConfig
+            versionDependentConfig: versionDependentConfig
         )
         let candidateTextForEvaluation = self.candidateTextForEvaluation(
-            candidateText: projection.candidateText,
-            input: projection.input,
+            candidateText: candidate.text,
+            input: input,
             inputCursorPosition: inputCursorPosition,
-            versionDependentConfig: projection.versionDependentConfig
+            versionDependentConfig: versionDependentConfig
         )
         let normalizedPrompt = context.normalizeForModel(prompt)
         let prevPrompt = context.previousEvaluationPrompt()
@@ -166,9 +147,9 @@ struct ZenzCandidateEvaluator {
         let addressedTokens: [llama_token]
         if reusesAddressedPrefix {
             var prefix = ""
-            for character in projection.candidateText {
+            for character in candidate.text {
                 let newPrefix = prefix + String(character)
-                if projection.remainingConstraint.hasPrefix(newPrefix.utf8) {
+                if prefixConstraint.constraint.hasPrefix(newPrefix.utf8) {
                     prefix = newPrefix
                 } else {
                     break
@@ -319,8 +300,7 @@ struct ZenzCandidateEvaluator {
                         }
                         let data = Data(cchars.map { UInt8(bitPattern: $0) })
                         let string = String(data: data, encoding: .utf8) ?? ""
-                        let wholeResult = projection.stableCandidatePrefix
-                            + String(string.dropFirst(normalizedPrompt.count))
+                        let wholeResult = String(string.dropFirst(normalizedPrompt.count))
                         return finish(.wholeResult(wholeResult))
                     } else {
                         let candidateTokenIndex = i - promptTokens.count
@@ -336,8 +316,7 @@ struct ZenzCandidateEvaluator {
                             } + context.tokenToPiece(token: maxItem.token)
                             return finish(
                                 .fixRequired(
-                                    prefixConstraint: projection.stableCandidatePrefix.utf8
-                                        + cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                                    prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
                                 )
                             )
                         }
@@ -352,8 +331,7 @@ struct ZenzCandidateEvaluator {
                         altTokens.insertIfPossible(
                             AlternativeHighProbToken(
                                 token: item.token,
-                                constraint: projection.stableCandidatePrefix.utf8
-                                    + prefix.map(UInt8.init)
+                                constraint: prefix.map(UInt8.init)
                                     + context.tokenToPiece(token: item.token).map(UInt8.init),
                                 probabilityRatioToMaxProb: expf(item.logit - maxItem.logit)
                             )
@@ -414,92 +392,6 @@ struct ZenzCandidateEvaluator {
                     .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
                 }
             )
-        )
-    }
-
-    /// 直前のリクエストまでにモデルが受理した文節を左文脈へ移し、
-    /// 今回追加された範囲だけを評価する。
-    ///
-    /// 同一リクエスト内で新しく得た制約には適用せず、一括変換の探索は従来どおり。
-    /// 学習・ユーザ辞書・リッチ候補・カーソル途中入力でも、評価範囲の変更が
-    /// 各機能の意味を変えうるため全文を評価する。
-    private static func incrementalEvaluationProjection(
-        input: String,
-        inputCursorPosition: Int?,
-        candidate: Candidate,
-        requestRichCandidates: Bool,
-        prefixConstraint: Kana2Kanji.PrefixConstraint,
-        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
-        personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
-        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
-    ) -> IncrementalEvaluationProjection {
-        let unchanged = IncrementalEvaluationProjection(
-            stableCandidatePrefix: "",
-            input: input,
-            candidateText: candidate.text,
-            remainingConstraint: prefixConstraint.constraint,
-            versionDependentConfig: versionDependentConfig
-        )
-        guard inputCursorPosition == nil,
-              !requestRichCandidates,
-              personalizationMode == nil,
-              let incrementalPrefixConstraint,
-              !incrementalPrefixConstraint.constraint.isEmpty,
-              candidate.data.allSatisfy({
-                  $0.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary])
-              }) else {
-            return unchanged
-        }
-
-        var remainingInput = input[...]
-        var remainingConstraint = incrementalPrefixConstraint.constraint[...]
-        var matchedSegments: [(word: String, ruby: String)] = []
-        for data in candidate.data where !data.word.isEmpty {
-            let ruby = data.ruby.toKatakana()
-            let wordBytes = Array(data.word.utf8)
-            guard remainingInput.hasPrefix(ruby),
-                  remainingConstraint.hasPrefix(wordBytes) else {
-                break
-            }
-            matchedSegments.append((data.word, ruby))
-            remainingInput = remainingInput.dropFirst(ruby.count)
-            remainingConstraint = remainingConstraint.dropFirst(wordBytes.count)
-        }
-
-        // 直近の一致文節は、新しい入力によって再解釈できるよう評価対象に残す。
-        guard matchedSegments.count >= 2 else {
-            return unchanged
-        }
-        let stableSegments = matchedSegments.dropLast()
-        let stableCandidatePrefix = stableSegments.reduce(into: "") { $0 += $1.word }
-        let stableRubyPrefix = stableSegments.reduce(into: "") { $0 += $1.ruby }
-        guard candidate.text.hasPrefix(stableCandidatePrefix),
-              input.hasPrefix(stableRubyPrefix),
-              incrementalPrefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8),
-              prefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8) else {
-            return unchanged
-        }
-
-        let projectedInput = String(input.dropFirst(stableRubyPrefix.count))
-        let projectedCandidate = String(candidate.text.dropFirst(stableCandidatePrefix.count))
-        let projectedConstraint = Array(
-            prefixConstraint.constraint.dropFirst(stableCandidatePrefix.utf8.count)
-        )
-        let projectedConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
-        switch versionDependentConfig {
-        case .v2(var mode):
-            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
-            projectedConfig = .v2(mode)
-        case .v3(var mode):
-            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
-            projectedConfig = .v3(mode)
-        }
-        return IncrementalEvaluationProjection(
-            stableCandidatePrefix: stableCandidatePrefix,
-            input: projectedInput,
-            candidateText: projectedCandidate,
-            remainingConstraint: projectedConstraint,
-            versionDependentConfig: projectedConfig
         )
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -78,6 +78,14 @@ final class ZenzEvaluationCache: @unchecked Sendable {
 }
 
 struct ZenzCandidateEvaluator {
+    private struct IncrementalEvaluationProjection {
+        var stableCandidatePrefix: String
+        var input: String
+        var candidateText: String
+        var remainingConstraint: [UInt8]
+        var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    }
+
     static func evaluate(
         context: ZenzContext,
         input: String,
@@ -85,25 +93,36 @@ struct ZenzCandidateEvaluator {
         candidate: Candidate,
         requestRichCandidates: Bool,
         prefixConstraint: Kana2Kanji.PrefixConstraint,
+        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
     ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
+        let projection = self.incrementalEvaluationProjection(
+            input: input,
+            inputCursorPosition: inputCursorPosition,
+            candidate: candidate,
+            requestRichCandidates: requestRichCandidates,
+            prefixConstraint: prefixConstraint,
+            incrementalPrefixConstraint: incrementalPrefixConstraint,
+            personalizationMode: personalizationMode,
+            versionDependentConfig: versionDependentConfig
+        )
         var userDictionaryPrompt = ""
         for item in candidate.data where item.metadata.contains(.isFromUserDictionary) {
             userDictionaryPrompt += "\(item.word)(\(item.ruby.toHiragana()))"
         }
         let prompt = ZenzPromptBuilder.candidateEvaluationPrompt(
-            input: input,
+            input: projection.input,
             inputCursorPosition: inputCursorPosition,
             userDictionaryPrompt: userDictionaryPrompt,
-            versionDependentConfig: versionDependentConfig
+            versionDependentConfig: projection.versionDependentConfig
         )
         let candidateTextForEvaluation = self.candidateTextForEvaluation(
-            candidateText: candidate.text,
-            input: input,
+            candidateText: projection.candidateText,
+            input: projection.input,
             inputCursorPosition: inputCursorPosition,
-            versionDependentConfig: versionDependentConfig
+            versionDependentConfig: projection.versionDependentConfig
         )
         let normalizedPrompt = context.normalizeForModel(prompt)
         let prevPrompt = context.previousEvaluationPrompt()
@@ -147,9 +166,9 @@ struct ZenzCandidateEvaluator {
         let addressedTokens: [llama_token]
         if reusesAddressedPrefix {
             var prefix = ""
-            for character in candidate.text {
+            for character in projection.candidateText {
                 let newPrefix = prefix + String(character)
-                if prefixConstraint.constraint.hasPrefix(newPrefix.utf8) {
+                if projection.remainingConstraint.hasPrefix(newPrefix.utf8) {
                     prefix = newPrefix
                 } else {
                     break
@@ -162,20 +181,26 @@ struct ZenzCandidateEvaluator {
 
         let tokens = promptTokens + candidateTokens
         let startOffset = promptTokens.count - 1 + addressedTokens.count
-        guard let logits = context.evaluationLogits(tokens: tokens, startOffset: startOffset) else {
-            debug("logits unavailable")
-            return .error
-        }
         let n_vocab = Int(context.vocabSize)
-        let candidateLearnedTokens: [(isLearned: Bool, priority: Float)] = candidate.data.flatMap {
-            Array(repeating: ($0.metadata.contains(.isLearned), logf(self.learningPriority(data: $0))), count: context.encode($0.word, addBOS: false).count)
-        }
-        let candidateTokenMetadata = if candidateLearnedTokens.count >= candidateTokens.count {
-            Array(candidateLearnedTokens.prefix(candidateTokens.count))
+        let learnedTokenPriorities: [Float]?
+        if candidate.data.contains(where: { $0.metadata.contains(.isLearned) }) {
+            let candidateLearnedTokens = candidate.data.flatMap {
+                Array(
+                    repeating: $0.metadata.contains(.isLearned) ? logf(self.learningPriority(data: $0)) : 0,
+                    count: context.encode($0.word, addBOS: false).count
+                )
+            }
+            if candidateLearnedTokens.count >= candidateTokens.count {
+                learnedTokenPriorities = Array(candidateLearnedTokens.prefix(candidateTokens.count))
+            } else {
+                learnedTokenPriorities = candidateLearnedTokens + Array(
+                    repeating: 0,
+                    count: candidateTokens.count - candidateLearnedTokens.count
+                )
+            }
         } else {
-            candidateLearnedTokens + Array(repeating: (false, 0), count: candidateTokens.count - candidateLearnedTokens.count)
+            learnedTokenPriorities = nil
         }
-        let isLearnedToken: [(isLearned: Bool, priority: Float)] = Array(repeating: (false, 0), count: promptTokens.count) + candidateTokenMetadata
 
         var score: Float = 0
 
@@ -189,92 +214,198 @@ struct ZenzCandidateEvaluator {
             var probabilityRatioToMaxProb: Float
         }
 
-        struct TokenAndLogprob: Comparable {
-            static func < (lhs: TokenAndLogprob, rhs: TokenAndLogprob) -> Bool {
-                lhs.logprob < rhs.logprob
+        struct TokenAndLogit: Comparable {
+            static func < (lhs: TokenAndLogit, rhs: TokenAndLogit) -> Bool {
+                lhs.logit < rhs.logit
             }
             var token: llama_token
-            var logprob: Float
+            var logit: Float
         }
 
         var altTokens = FixedSizeHeap<AlternativeHighProbToken>(size: requestRichCandidates ? 5 : 0)
-        for (i, tokenID) in tokens.indexed().dropFirst(startOffset + 1) {
-            var sumexp: Float = 0
-            let startIndex = (i - 1 - startOffset) * Int(n_vocab)
-            let endIndex = (i - startOffset) * Int(n_vocab)
-            var tokenHeap = FixedSizeHeap<TokenAndLogprob>(size: requestRichCandidates ? 3 : 1)
-            for index in startIndex ..< endIndex {
-                sumexp += expf(logits[index])
-            }
-            let logsumexp = logf(sumexp)
+        func evaluateTokenRange(
+            _ range: Range<Int>,
+            logits: UnsafeMutablePointer<Float>,
+            logitsStartIndex: Int
+        ) -> CandidateEvaluationResult? {
+            for i in range {
+                let tokenID = tokens[i]
+                let startIndex = (i - 1 - logitsStartIndex) * n_vocab
+                let endIndex = startIndex + n_vocab
+                var tokenHeap = FixedSizeHeap<TokenAndLogit>(size: requestRichCandidates ? 3 : 0)
+                let maxItem: TokenAndLogit
 
-            if let (mode, baseLM, personalLM) = personalizationMode, mode.alpha > 0 {
-                let prefix = tokens[..<i].dropFirst(promptTokens.count).map(Int.init)
-                let baseProb: [Float]
-                let personalProb: [Float]
-                if !prefix.isEmpty {
-                    baseProb = baseLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
-                    personalProb = personalLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
-                } else {
-                    baseProb = Array(repeating: 0, count: Int(n_vocab))
-                    personalProb = baseProb
-                }
-                for (vocabIndex, (lpb, lpp)) in zip(0 ..< Int(n_vocab), zip(baseProb, personalProb)) {
-                    let logp = logits[startIndex + vocabIndex] - logsumexp
-                    let personalizedLogp = logp + mode.alpha * (lpp - lpb)
-                    tokenHeap.insertIfPossible(TokenAndLogprob(token: llama_token(vocabIndex), logprob: personalizedLogp))
-                }
-            } else {
-                for index in startIndex ..< endIndex {
-                    let logp = logits[index] - logsumexp
-                    tokenHeap.insertIfPossible(TokenAndLogprob(token: llama_token(index - startIndex), logprob: logp))
-                }
-            }
-
-            guard let maxItem = tokenHeap.max else {
-                debug("Max Item could not be found for unknown reason")
-                return .error
-            }
-            if maxItem.token != tokenID {
-                if maxItem.token == context.eosToken {
-                    let cchars: [CChar] = tokens[..<i].reduce(into: []) {
-                        $0.append(contentsOf: context.tokenToPiece(token: $1))
+                if let (mode, baseLM, personalLM) = personalizationMode, mode.alpha > 0 {
+                    let prefix = tokens[..<i].dropFirst(promptTokens.count).map(Int.init)
+                    let baseProb: [Float]
+                    let personalProb: [Float]
+                    if !prefix.isEmpty {
+                        baseProb = baseLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
+                        personalProb = personalLM.bulkPredict(prefix).map { logf(Float($0) + 1e-7) }
+                    } else {
+                        baseProb = Array(repeating: 0, count: n_vocab)
+                        personalProb = baseProb
                     }
-                    let data = Data(cchars.map { UInt8(bitPattern: $0) })
-                    let string = String(data: data, encoding: .utf8) ?? ""
-                    let wholeResult = String(string.dropFirst(normalizedPrompt.count))
-                    return finish(.wholeResult(wholeResult))
+                    if requestRichCandidates {
+                        for (vocabIndex, (lpb, lpp)) in zip(
+                            0 ..< n_vocab,
+                            zip(baseProb, personalProb)
+                        ) {
+                            let personalizedLogit = logits[startIndex + vocabIndex]
+                                + mode.alpha * (lpp - lpb)
+                            tokenHeap.insertIfPossible(
+                                TokenAndLogit(
+                                    token: llama_token(vocabIndex),
+                                    logit: personalizedLogit
+                                )
+                            )
+                        }
+                        guard let maximum = tokenHeap.max else {
+                            debug("Max Item could not be found for unknown reason")
+                            return .error
+                        }
+                        maxItem = maximum
+                    } else {
+                        var maximum = TokenAndLogit(
+                            token: 0,
+                            logit: logits[startIndex] + mode.alpha * (personalProb[0] - baseProb[0])
+                        )
+                        for vocabIndex in 1 ..< n_vocab {
+                            let personalizedLogit = logits[startIndex + vocabIndex]
+                                + mode.alpha * (personalProb[vocabIndex] - baseProb[vocabIndex])
+                            if personalizedLogit > maximum.logit {
+                                maximum = TokenAndLogit(
+                                    token: llama_token(vocabIndex),
+                                    logit: personalizedLogit
+                                )
+                            }
+                        }
+                        maxItem = maximum
+                    }
+                } else if requestRichCandidates {
+                    for index in startIndex ..< endIndex {
+                        tokenHeap.insertIfPossible(
+                            TokenAndLogit(
+                                token: llama_token(index - startIndex),
+                                logit: logits[index]
+                            )
+                        )
+                    }
+                    guard let maximum = tokenHeap.max else {
+                        debug("Max Item could not be found for unknown reason")
+                        return .error
+                    }
+                    maxItem = maximum
                 } else {
-                    let actualLogp = logits[startIndex + Int(tokenID)] - logsumexp
-                    let preferLearnedToken = isLearnedToken[i].isLearned && actualLogp + isLearnedToken[i].priority > maxItem.logprob
-                    if !preferLearnedToken {
+                    var maximumToken = 0
+                    var maximumLogit = logits[startIndex]
+                    for vocabIndex in 1 ..< n_vocab {
+                        let logit = logits[startIndex + vocabIndex]
+                        if logit > maximumLogit {
+                            maximumToken = vocabIndex
+                            maximumLogit = logit
+                        }
+                    }
+                    maxItem = TokenAndLogit(
+                        token: llama_token(maximumToken),
+                        logit: maximumLogit
+                    )
+                }
+
+                if maxItem.token != tokenID {
+                    if maxItem.token == context.eosToken {
                         let cchars = tokens[..<i].reduce(into: []) {
                             $0.append(contentsOf: context.tokenToPiece(token: $1))
-                        } + context.tokenToPiece(token: maxItem.token)
-                        return finish(
-                            .fixRequired(
-                                prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                        }
+                        let data = Data(cchars.map { UInt8(bitPattern: $0) })
+                        let string = String(data: data, encoding: .utf8) ?? ""
+                        let wholeResult = projection.stableCandidatePrefix
+                            + String(string.dropFirst(normalizedPrompt.count))
+                        return finish(.wholeResult(wholeResult))
+                    } else {
+                        let candidateTokenIndex = i - promptTokens.count
+                        let learnedPriority = learnedTokenPriorities.map {
+                            candidateTokenIndex < $0.count ? $0[candidateTokenIndex] : 0
+                        } ?? 0
+                        // softmaxの正規化項は両辺で相殺されるため、logitのまま比較できる。
+                        let preferLearnedToken = learnedPriority > 0
+                            && logits[startIndex + Int(tokenID)] + learnedPriority > maxItem.logit
+                        if !preferLearnedToken {
+                            let cchars = tokens[..<i].reduce(into: []) {
+                                $0.append(contentsOf: context.tokenToPiece(token: $1))
+                            } + context.tokenToPiece(token: maxItem.token)
+                            return finish(
+                                .fixRequired(
+                                    prefixConstraint: projection.stableCandidatePrefix.utf8
+                                        + cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                                )
+                            )
+                        }
+                    }
+                } else if requestRichCandidates {
+                    tokenHeap.removeMax()
+                    let prefix = tokens[..<i].reduce(into: []) {
+                        $0.append(contentsOf: context.tokenToPiece(token: $1))
+                    }.dropFirst(normalizedPrompt.utf8.count)
+
+                    for item in tokenHeap.unordered {
+                        altTokens.insertIfPossible(
+                            AlternativeHighProbToken(
+                                token: item.token,
+                                constraint: projection.stableCandidatePrefix.utf8
+                                    + prefix.map(UInt8.init)
+                                    + context.tokenToPiece(token: item.token).map(UInt8.init),
+                                probabilityRatioToMaxProb: expf(item.logit - maxItem.logit)
                             )
                         )
                     }
                 }
-            } else if !tokenHeap.isEmpty {
-                tokenHeap.removeMax()
-                let prefix = tokens[..<i].reduce(into: []) {
-                    $0.append(contentsOf: context.tokenToPiece(token: $1))
-                }.dropFirst(normalizedPrompt.utf8.count)
+                // この値は順位付けには使われない。正規化項の全語彙走査を避けるため、
+                // 等価な順位を持つ未正規化logitを蓄積する。
+                score += maxItem.logit
+            }
+            return nil
+        }
 
-                for item in tokenHeap.unordered {
-                    altTokens.insertIfPossible(
-                        AlternativeHighProbToken(
-                            token: item.token,
-                            constraint: prefix.map(UInt8.init) + context.tokenToPiece(token: item.token).map(UInt8.init),
-                            probabilityRatioToMaxProb: expf(item.logprob - maxItem.logprob)
-                        )
-                    )
+        let firstTokenIndex = startOffset + 1
+        if firstTokenIndex < tokens.endIndex {
+            // 修正要求は候補の冒頭で確定することが多い。最初の少数tokenだけを
+            // decodeして判定し、必要な場合に限って残りを一括decodeする。
+            let firstChunkEndIndex = min(tokens.endIndex, firstTokenIndex + 4)
+            let firstChunkTokens = Array(tokens[..<firstChunkEndIndex])
+            guard let logits = context.evaluationLogits(
+                tokens: firstChunkTokens,
+                startOffset: startOffset
+            ) else {
+                debug("logits unavailable")
+                return .error
+            }
+            if let result = evaluateTokenRange(
+                firstTokenIndex ..< firstChunkEndIndex,
+                logits: logits,
+                logitsStartIndex: startOffset
+            ) {
+                return result
+            }
+
+            if firstChunkEndIndex < tokens.endIndex {
+                // 境界直前のtokenをlogits付きで再計算し、続きの最初のtokenを評価する。
+                let continuationStartOffset = firstChunkEndIndex - 1
+                guard let logits = context.evaluationLogits(
+                    tokens: tokens,
+                    startOffset: continuationStartOffset
+                ) else {
+                    debug("logits unavailable")
+                    return .error
+                }
+                if let result = evaluateTokenRange(
+                    firstChunkEndIndex ..< tokens.endIndex,
+                    logits: logits,
+                    logitsStartIndex: continuationStartOffset
+                ) {
+                    return result
                 }
             }
-            score += maxItem.logprob
         }
         return finish(
             .pass(
@@ -283,6 +414,92 @@ struct ZenzCandidateEvaluator {
                     .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
                 }
             )
+        )
+    }
+
+    /// 直前のリクエストまでにモデルが受理した文節を左文脈へ移し、
+    /// 今回追加された範囲だけを評価する。
+    ///
+    /// 同一リクエスト内で新しく得た制約には適用せず、一括変換の探索は従来どおり。
+    /// 学習・ユーザ辞書・リッチ候補・カーソル途中入力でも、評価範囲の変更が
+    /// 各機能の意味を変えうるため全文を評価する。
+    private static func incrementalEvaluationProjection(
+        input: String,
+        inputCursorPosition: Int?,
+        candidate: Candidate,
+        requestRichCandidates: Bool,
+        prefixConstraint: Kana2Kanji.PrefixConstraint,
+        incrementalPrefixConstraint: Kana2Kanji.PrefixConstraint?,
+        personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
+        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    ) -> IncrementalEvaluationProjection {
+        let unchanged = IncrementalEvaluationProjection(
+            stableCandidatePrefix: "",
+            input: input,
+            candidateText: candidate.text,
+            remainingConstraint: prefixConstraint.constraint,
+            versionDependentConfig: versionDependentConfig
+        )
+        guard inputCursorPosition == nil,
+              !requestRichCandidates,
+              personalizationMode == nil,
+              let incrementalPrefixConstraint,
+              !incrementalPrefixConstraint.constraint.isEmpty,
+              candidate.data.allSatisfy({
+                  $0.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary])
+              }) else {
+            return unchanged
+        }
+
+        var remainingInput = input[...]
+        var remainingConstraint = incrementalPrefixConstraint.constraint[...]
+        var matchedSegments: [(word: String, ruby: String)] = []
+        for data in candidate.data where !data.word.isEmpty {
+            let ruby = data.ruby.toKatakana()
+            let wordBytes = Array(data.word.utf8)
+            guard remainingInput.hasPrefix(ruby),
+                  remainingConstraint.hasPrefix(wordBytes) else {
+                break
+            }
+            matchedSegments.append((data.word, ruby))
+            remainingInput = remainingInput.dropFirst(ruby.count)
+            remainingConstraint = remainingConstraint.dropFirst(wordBytes.count)
+        }
+
+        // 直近の一致文節は、新しい入力によって再解釈できるよう評価対象に残す。
+        guard matchedSegments.count >= 2 else {
+            return unchanged
+        }
+        let stableSegments = matchedSegments.dropLast()
+        let stableCandidatePrefix = stableSegments.reduce(into: "") { $0 += $1.word }
+        let stableRubyPrefix = stableSegments.reduce(into: "") { $0 += $1.ruby }
+        guard candidate.text.hasPrefix(stableCandidatePrefix),
+              input.hasPrefix(stableRubyPrefix),
+              incrementalPrefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8),
+              prefixConstraint.constraint.hasPrefix(stableCandidatePrefix.utf8) else {
+            return unchanged
+        }
+
+        let projectedInput = String(input.dropFirst(stableRubyPrefix.count))
+        let projectedCandidate = String(candidate.text.dropFirst(stableCandidatePrefix.count))
+        let projectedConstraint = Array(
+            prefixConstraint.constraint.dropFirst(stableCandidatePrefix.utf8.count)
+        )
+        let projectedConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+        switch versionDependentConfig {
+        case .v2(var mode):
+            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
+            projectedConfig = .v2(mode)
+        case .v3(var mode):
+            mode.leftSideContext = (mode.leftSideContext ?? "") + stableCandidatePrefix
+            projectedConfig = .v3(mode)
+        }
+        return IncrementalEvaluationProjection(
+            stableCandidatePrefix: stableCandidatePrefix,
+            input: projectedInput,
+            candidateText: projectedCandidate,
+            remainingConstraint: projectedConstraint,
+            versionDependentConfig: projectedConfig
         )
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -19,6 +19,64 @@ enum CandidateEvaluationResult: Sendable, Equatable, Hashable {
     }
 }
 
+struct ZenzEvaluationCacheKey: Sendable, Equatable, Hashable {
+    struct CandidateSegment: Sendable, Equatable, Hashable {
+        var word: String
+        var ruby: String
+        var isLearned: Bool
+    }
+
+    var prompt: String
+    var candidateTextForEvaluation: String
+    var originalCandidateText: String
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+    var requestRichCandidates: Bool
+    var reusesAddressedPrefix: Bool
+    var candidateSegments: [CandidateSegment]
+}
+
+/// モデル評価結果を少量だけ保持する、スレッドセーフなLRUキャッシュ。
+final class ZenzEvaluationCache: @unchecked Sendable {
+    private struct Entry {
+        var result: CandidateEvaluationResult
+        var accessIndex: UInt64
+    }
+
+    init(capacity: Int) {
+        self.capacity = max(1, capacity)
+    }
+
+    func value(for key: ZenzEvaluationCacheKey) -> CandidateEvaluationResult? {
+        self.lock.withLock {
+            guard var entry = self.entries[key] else {
+                return nil
+            }
+            self.accessIndex &+= 1
+            entry.accessIndex = self.accessIndex
+            self.entries[key] = entry
+            return entry.result
+        }
+    }
+
+    func insert(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
+        self.lock.withLock {
+            self.accessIndex &+= 1
+            if self.entries[key] == nil, self.entries.count >= self.capacity,
+               let leastRecentlyUsedKey = self.entries.min(by: {
+                   $0.value.accessIndex < $1.value.accessIndex
+               })?.key {
+                self.entries[leastRecentlyUsedKey] = nil
+            }
+            self.entries[key] = Entry(result: result, accessIndex: self.accessIndex)
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [ZenzEvaluationCacheKey: Entry] = [:]
+    private var accessIndex: UInt64 = 0
+    private let lock = NSLock()
+}
+
 struct ZenzCandidateEvaluator {
     static func evaluate(
         context: ZenzContext,
@@ -48,15 +106,46 @@ struct ZenzCandidateEvaluator {
             versionDependentConfig: versionDependentConfig
         )
         let normalizedPrompt = context.normalizeForModel(prompt)
-        let promptTokens = context.encode(prompt, addBOS: true, addEOS: false)
+        let prevPrompt = context.previousEvaluationPrompt()
+        let reusesAddressedPrefix = prevPrompt == normalizedPrompt && !requestRichCandidates
+        // A cache hit must produce the same subsequent incremental-evaluation state
+        // as a model evaluation.
         defer {
-            context.setPreviousEvaluationPromptTokens(promptTokens)
+            context.setPreviousEvaluationPrompt(normalizedPrompt)
         }
-        let prevPrompt = context.previousEvaluationPromptTokens()
+        let cacheKey: ZenzEvaluationCacheKey? = if personalizationMode == nil {
+            ZenzEvaluationCacheKey(
+                prompt: prompt,
+                candidateTextForEvaluation: candidateTextForEvaluation,
+                originalCandidateText: candidate.text,
+                prefixConstraint: prefixConstraint,
+                requestRichCandidates: requestRichCandidates,
+                reusesAddressedPrefix: reusesAddressedPrefix,
+                candidateSegments: candidate.data.map {
+                    .init(
+                        word: $0.word,
+                        ruby: $0.ruby,
+                        isLearned: $0.metadata.contains(.isLearned)
+                    )
+                }
+            )
+        } else {
+            nil
+        }
+        if let cacheKey, let cached = context.cachedEvaluation(for: cacheKey) {
+            return cached
+        }
+        func finish(_ result: CandidateEvaluationResult) -> CandidateEvaluationResult {
+            if let cacheKey, result != .error {
+                context.cacheEvaluation(result, for: cacheKey)
+            }
+            return result
+        }
 
+        let promptTokens = context.encodeEvaluationPrompt(prompt)
         let candidateTokens = context.encode(candidateTextForEvaluation, addBOS: false, addEOS: false)
         let addressedTokens: [llama_token]
-        if prevPrompt == promptTokens, !requestRichCandidates {
+        if reusesAddressedPrefix {
             var prefix = ""
             for character in candidate.text {
                 let newPrefix = prefix + String(character)
@@ -154,7 +243,7 @@ struct ZenzCandidateEvaluator {
                     let data = Data(cchars.map { UInt8(bitPattern: $0) })
                     let string = String(data: data, encoding: .utf8) ?? ""
                     let wholeResult = String(string.dropFirst(normalizedPrompt.count))
-                    return .wholeResult(wholeResult)
+                    return finish(.wholeResult(wholeResult))
                 } else {
                     let actualLogp = logits[startIndex + Int(tokenID)] - logsumexp
                     let preferLearnedToken = isLearnedToken[i].isLearned && actualLogp + isLearnedToken[i].priority > maxItem.logprob
@@ -162,7 +251,11 @@ struct ZenzCandidateEvaluator {
                         let cchars = tokens[..<i].reduce(into: []) {
                             $0.append(contentsOf: context.tokenToPiece(token: $1))
                         } + context.tokenToPiece(token: maxItem.token)
-                        return .fixRequired(prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init))
+                        return finish(
+                            .fixRequired(
+                                prefixConstraint: cchars.dropFirst(normalizedPrompt.utf8.count).map(UInt8.init)
+                            )
+                        )
                     }
                 }
             } else if !tokenHeap.isEmpty {
@@ -183,11 +276,13 @@ struct ZenzCandidateEvaluator {
             }
             score += maxItem.logprob
         }
-        return .pass(
-            score: score,
-            alternativeConstraints: altTokens.unordered.sorted(by: >).map {
-                .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
-            }
+        return finish(
+            .pass(
+                score: score,
+                alternativeConstraints: altTokens.unordered.sorted(by: >).map {
+                    .init(probabilityRatio: $0.probabilityRatioToMaxProb, prefixConstraint: $0.constraint)
+                }
+            )
         )
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -347,42 +347,22 @@ struct ZenzCandidateEvaluator {
 
         let firstTokenIndex = startOffset + 1
         if firstTokenIndex < tokens.endIndex {
-            // 修正要求は候補の冒頭で確定することが多い。最初の少数tokenだけを
-            // decodeして判定し、必要な場合に限って残りを一括decodeする。
-            let firstChunkEndIndex = min(tokens.endIndex, firstTokenIndex + 4)
-            let firstChunkTokens = Array(tokens[..<firstChunkEndIndex])
+            // token i の判定に必要なのは token i - 1 のlogitsまでなので、
+            // 最終候補token自体はdecodeしない。
+            let evaluationTokens = Array(tokens.dropLast())
             guard let logits = context.evaluationLogits(
-                tokens: firstChunkTokens,
+                tokens: evaluationTokens,
                 startOffset: startOffset
             ) else {
                 debug("logits unavailable")
                 return .error
             }
             if let result = evaluateTokenRange(
-                firstTokenIndex ..< firstChunkEndIndex,
+                firstTokenIndex ..< tokens.endIndex,
                 logits: logits,
                 logitsStartIndex: startOffset
             ) {
                 return result
-            }
-
-            if firstChunkEndIndex < tokens.endIndex {
-                // 境界直前のtokenをlogits付きで再計算し、続きの最初のtokenを評価する。
-                let continuationStartOffset = firstChunkEndIndex - 1
-                guard let logits = context.evaluationLogits(
-                    tokens: tokens,
-                    startOffset: continuationStartOffset
-                ) else {
-                    debug("logits unavailable")
-                    return .error
-                }
-                if let result = evaluateTokenRange(
-                    firstChunkEndIndex ..< tokens.endIndex,
-                    logits: logits,
-                    logitsStartIndex: continuationStartOffset
-                ) {
-                    return result
-                }
             }
         }
         return finish(

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -143,6 +143,11 @@ private final class SharedZenzModel {
         ZenzBackend.initializeIfNeeded()
         var modelParams = llama_model_default_params()
         modelParams.use_mmap = true
+        #if ZenzaiCPU && os(iOS)
+        // b9637のCPU weight repackはモデルと同程度の追加bufferを常駐させる。
+        // iOSのメモリ制約を優先し、mmapされた元の量子化weightを直接利用する。
+        modelParams.use_extra_bufts = false
+        #endif
         #if ZenzaiCPU
         modelParams.n_gpu_layers = 0
         modelParams.split_mode = LLAMA_SPLIT_MODE_NONE

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -52,16 +52,16 @@ private final class ZenzTokenArrayBox {
 }
 
 struct ZenzResolvedConversionCacheKey: Equatable, Hashable {
-    var dictionaryIdentifier: ObjectIdentifier
     var input: [ComposingText.InputElement]
     var convertTarget: String
     var convertTargetCursorPosition: Int?
     var keyboardLanguage: KeyboardLanguage
     var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+    var inferenceLimit: Int
 }
 
 struct ZenzDraftConversionCacheKey: Equatable, Hashable {
-    var dictionaryIdentifier: ObjectIdentifier
     var input: [ComposingText.InputElement]
     var convertTarget: String
     var convertTargetCursorPosition: Int?
@@ -199,6 +199,77 @@ final class ZenzDraftConversionCache: @unchecked Sendable {
     private let lock = NSLock()
 }
 
+/// 1つの変換セッション内だけで再利用するZenzaiのメモ化キャッシュ。
+///
+/// モデルやnative contextとは所有者を分け、Converterのセッション終了時に確実に
+/// 破棄されるようにする。これにより、別セッションや別テストの同一入力が以前の
+/// 変換結果を引き継がない。
+final class ZenzaiSessionCache: @unchecked Sendable {
+    init(
+        evaluationCapacity: Int = 256,
+        resolvedConversionCapacity: Int = 64,
+        draftConversionCapacity: Int = 128,
+        promptTokenCapacity: Int = 128
+    ) {
+        self.evaluationCache = ZenzEvaluationCache(capacity: evaluationCapacity)
+        self.resolvedConversionCache = ZenzResolvedConversionCache(
+            capacity: resolvedConversionCapacity
+        )
+        self.draftConversionCache = ZenzDraftConversionCache(
+            capacity: draftConversionCapacity
+        )
+        self.evaluationPromptTokenCache.countLimit = promptTokenCapacity
+    }
+
+    func cachedEvaluation(for key: ZenzEvaluationCacheKey) -> CandidateEvaluationResult? {
+        self.evaluationCache.value(for: key)
+    }
+
+    func cacheEvaluation(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
+        self.evaluationCache.insert(result, for: key)
+    }
+
+    func cachedResolvedConversion(
+        for key: ZenzResolvedConversionCacheKey
+    ) -> ZenzResolvedConversion? {
+        self.resolvedConversionCache.value(for: key)
+    }
+
+    func cacheResolvedConversion(
+        _ value: ZenzResolvedConversion,
+        for key: ZenzResolvedConversionCacheKey
+    ) {
+        self.resolvedConversionCache.insert(value, for: key)
+    }
+
+    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.draftConversionCache.value(for: key)
+    }
+
+    func cacheDraftConversion(
+        _ value: ZenzDraftConversion,
+        for key: ZenzDraftConversionCacheKey
+    ) {
+        self.draftConversionCache.insert(value, for: key)
+    }
+
+    func cachedEvaluationPromptTokens(for prompt: String) -> [llama_token]? {
+        self.evaluationPromptTokenCache.object(forKey: prompt as NSString)?.tokens
+    }
+
+    func cacheEvaluationPromptTokens(_ tokens: [llama_token], for prompt: String) {
+        self.evaluationPromptTokenCache.setObject(
+            ZenzTokenArrayBox(tokens),
+            forKey: prompt as NSString
+        )
+    }
+
+    private let evaluationCache: ZenzEvaluationCache
+    private let resolvedConversionCache: ZenzResolvedConversionCache
+    private let draftConversionCache: ZenzDraftConversionCache
+    private let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
+}
+
 /// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
 ///
 /// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
@@ -241,10 +312,6 @@ private final class SharedZenzModel {
         }
         self.model = model
         self.vocab = vocab
-        self.evaluationCache = ZenzEvaluationCache(capacity: 256)
-        self.resolvedConversionCache = ZenzResolvedConversionCache(capacity: 64)
-        self.draftConversionCache = ZenzDraftConversionCache(capacity: 128)
-        self.evaluationPromptTokenCache.countLimit = 128
     }
 
     deinit {
@@ -253,10 +320,6 @@ private final class SharedZenzModel {
 
     let model: OpaquePointer
     let vocab: OpaquePointer
-    let evaluationCache: ZenzEvaluationCache
-    fileprivate let resolvedConversionCache: ZenzResolvedConversionCache
-    fileprivate let draftConversionCache: ZenzDraftConversionCache
-    let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
 }
 
 /// 同時に強参照するモデルを1個に制限する、プロセス共通のモデルキャッシュ。
@@ -292,7 +355,6 @@ final class ZenzContext {
     private var batch: llama_batch
     private var prevInputBySeq: [llama_seq_id: [llama_token]] = [:]
     private var prevPromptBySeq: [llama_seq_id: String] = [:]
-    private var evaluationPromptTokenCache: (prompt: String, tokens: [llama_token])?
 
     private let n_len: Int32 = 512
     private let evalSeqId: llama_seq_id = 0
@@ -500,50 +562,19 @@ final class ZenzContext {
         self.prevPromptBySeq[evalSeqId] = prompt
     }
 
-    func cachedEvaluation(for key: ZenzEvaluationCacheKey) -> CandidateEvaluationResult? {
-        self.sharedModel.evaluationCache.value(for: key)
-    }
-
-    func cacheEvaluation(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
-        self.sharedModel.evaluationCache.insert(result, for: key)
-    }
-
-    func cachedResolvedConversion(
-        for key: ZenzResolvedConversionCacheKey
-    ) -> ZenzResolvedConversion? {
-        self.sharedModel.resolvedConversionCache.value(for: key)
-    }
-
-    func cacheResolvedConversion(
-        _ value: ZenzResolvedConversion,
-        for key: ZenzResolvedConversionCacheKey
-    ) {
-        self.sharedModel.resolvedConversionCache.insert(value, for: key)
-    }
-
-    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
-        self.sharedModel.draftConversionCache.value(for: key)
-    }
-
-    func cacheDraftConversion(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
-        self.sharedModel.draftConversionCache.insert(value, for: key)
-    }
-
     func normalizeForModel(_ text: String) -> String {
         self.preprocessText(text: text)
     }
 
-    func encodeEvaluationPrompt(_ prompt: String) -> [llama_token] {
-        if let cached = self.evaluationPromptTokenCache, cached.prompt == prompt {
-            return cached.tokens
-        }
-        if let cached = self.sharedModel.evaluationPromptTokenCache.object(forKey: prompt as NSString) {
-            self.evaluationPromptTokenCache = (prompt, cached.tokens)
-            return cached.tokens
+    func encodeEvaluationPrompt(
+        _ prompt: String,
+        sessionCache: ZenzaiSessionCache
+    ) -> [llama_token] {
+        if let cached = sessionCache.cachedEvaluationPromptTokens(for: prompt) {
+            return cached
         }
         let tokens = self.encode(prompt, addBOS: true, addEOS: false)
-        self.evaluationPromptTokenCache = (prompt, tokens)
-        self.sharedModel.evaluationPromptTokenCache.setObject(ZenzTokenArrayBox(tokens), forKey: prompt as NSString)
+        sessionCache.cacheEvaluationPromptTokens(tokens, for: prompt)
         return tokens
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -244,6 +244,8 @@ final class ZenzContext {
         ctx_params.n_ubatch = 64
         #endif
         ctx_params.flash_attn = true
+        // 推論時間は呼び出し側で計測する。llama.cpp内部の統計更新は不要。
+        ctx_params.no_perf = true
         return ctx_params
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -2,6 +2,9 @@
 // Zenzai/ZenzaiCPU が有効でない場合、llama-mock.swift の実装が利用される
 import llama
 #endif
+#if canImport(Darwin)
+import Darwin
+#endif
 
 import Algorithms
 import Foundation
@@ -21,73 +24,207 @@ enum ZenzError: LocalizedError {
     }
 }
 
+/// llama.cpp のバックエンドはプロセス単位で一度だけ初期化する。
+///
+/// `llama_backend_free()` は現在 MPI 用の後始末にしか使われないため、モデルや
+/// コンテキストより先に解放される可能性があるプロセス終了時の明示解放は行わない。
+private enum ZenzBackend {
+    private static let initialized: Void = {
+        llama_backend_init()
+    }()
+
+    static func initializeIfNeeded() {
+        _ = self.initialized
+    }
+}
+
+private final class ZenzTokenArrayBox {
+    init(_ tokens: [llama_token]) {
+        self.tokens = tokens
+    }
+
+    let tokens: [llama_token]
+}
+
+/// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
+///
+/// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
+/// 共有することで、同じモデルを利用するConverterごとの再ロードを避ける。
+private final class SharedZenzModel {
+    init(path: String) throws {
+        ZenzBackend.initializeIfNeeded()
+        var modelParams = llama_model_default_params()
+        modelParams.use_mmap = true
+        #if ZenzaiCPU
+        modelParams.n_gpu_layers = 0
+        modelParams.split_mode = LLAMA_SPLIT_MODE_NONE
+        guard let cpuDevice = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU) else {
+            debug("Could not find CPU backend")
+            throw ZenzError.couldNotLoadModel(path: path)
+        }
+        // NULL終端のCPU-onlyデバイスリストを渡す。`n_gpu_layers = 0`だけでは
+        // llama.cppがMetalデバイスも列挙し、context生成時に初期化してしまう。
+        var devices = [cpuDevice, nil]
+        let loadedModel = devices.withUnsafeMutableBufferPointer { buffer in
+            modelParams.devices = buffer.baseAddress
+            return llama_model_load_from_file(path, modelParams)
+        }
+        #else
+        let loadedModel = llama_model_load_from_file(path, modelParams)
+        #endif
+        guard let model = loadedModel else {
+            debug("Could not load model at \(path)")
+            throw ZenzError.couldNotLoadModel(path: path)
+        }
+        guard let vocab = llama_model_get_vocab(model) else {
+            llama_model_free(model)
+            debug("Could not load vocab!")
+            throw ZenzError.couldNotLoadVocab
+        }
+        self.model = model
+        self.vocab = vocab
+        self.evaluationCache = ZenzEvaluationCache(capacity: 256)
+        self.evaluationPromptTokenCache.countLimit = 128
+    }
+
+    deinit {
+        llama_model_free(self.model)
+    }
+
+    let model: OpaquePointer
+    let vocab: OpaquePointer
+    let evaluationCache: ZenzEvaluationCache
+    let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
+}
+
+/// 同時に強参照するモデルを1個に制限する、プロセス共通のモデルキャッシュ。
+///
+/// `NSCache`にすることでメモリプレッシャー時にはモデルを解放できる。呼び出し側の
+/// `ZenzContext`もモデルを強参照するため、使用中のモデルが解放されることはない。
+private final class SharedZenzModelCache: @unchecked Sendable {
+    static let shared = SharedZenzModelCache()
+
+    private init() {
+        self.cache.countLimit = 1
+    }
+
+    func model(path: String) throws -> SharedZenzModel {
+        try self.lock.withLock {
+            let key = path as NSString
+            if let cached = self.cache.object(forKey: key) {
+                return cached
+            }
+            let model = try SharedZenzModel(path: path)
+            self.cache.setObject(model, forKey: key)
+            return model
+        }
+    }
+
+    private let cache = NSCache<NSString, SharedZenzModel>()
+    private let lock = NSLock()
+}
+
 final class ZenzContext {
-    private var model: OpaquePointer
+    private let sharedModel: SharedZenzModel
     private var context: OpaquePointer
-    private var vocab: OpaquePointer
+    private var batch: llama_batch
     private var prevInputBySeq: [llama_seq_id: [llama_token]] = [:]
-    private var prevPromptBySeq: [llama_seq_id: [llama_token]] = [:]
+    private var prevPromptBySeq: [llama_seq_id: String] = [:]
+    private var evaluationPromptTokenCache: (prompt: String, tokens: [llama_token])?
 
     private let n_len: Int32 = 512
     private let evalSeqId: llama_seq_id = 0
     private let inputPredictionSeqId: llama_seq_id = 1
 
-    init(model: OpaquePointer, context: OpaquePointer, vocab: OpaquePointer) {
-        self.model = model
+    private init(sharedModel: SharedZenzModel, context: OpaquePointer) {
+        self.sharedModel = sharedModel
         self.context = context
-        self.vocab = vocab
+        self.batch = llama_batch_init(512, 0, 1)
     }
 
     deinit {
+        llama_batch_free(self.batch)
         llama_free(context)
-        llama_model_free(model)
-        llama_backend_free()
     }
 
     private static var ctx_params: llama_context_params {
-        let n_threads = max(1, min(8, ProcessInfo.processInfo.processorCount - 2))
+        let n_threads = self.inferenceThreadCount
         debug("Using \(n_threads) threads")
         var ctx_params = llama_context_default_params()
         ctx_params.n_ctx = 512
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
+        ctx_params.flash_attn = true
         return ctx_params
     }
 
-    static func createContext(path: String) throws -> ZenzContext {
-        llama_backend_init()
-        var model_params = llama_model_default_params()
-        model_params.use_mmap = true
-        #if ZenzaiCPU
-        // CPU 専用: GPU へのオフロードを無効化
-        model_params.n_gpu_layers = 0
-        model_params.split_mode = LLAMA_SPLIT_MODE_NONE
+    /// 対話的な推論に使うCPUスレッド数を実行環境のトポロジーから決定する。
+    ///
+    /// Apple Siliconでは性能の異なるクラスタを跨ぐと短いdecodeのbarrier待ちが
+    /// 増えるため、最高性能クラスタの物理コア数を利用する。それ以外の環境では
+    /// OSへ応答性の余地を残しつつ、llama.cppの小規模モデルで過剰並列にならない
+    /// よう8スレッドを上限とする。
+    private static var inferenceThreadCount: Int {
+        let activeProcessorCount = max(1, ProcessInfo.processInfo.activeProcessorCount)
+        #if canImport(Darwin)
+        let performanceCoreCount = self.sysctlInt32("hw.perflevel0.physicalcpu")
+        #else
+        let performanceCoreCount: Int? = nil
         #endif
-        let model = llama_model_load_from_file(path, model_params)
-        guard let model else {
-            debug("Could not load model at \(path)")
-            throw ZenzError.couldNotLoadModel(path: path)
-        }
+        return self.selectInferenceThreadCount(
+            activeProcessorCount: activeProcessorCount,
+            performanceCoreCount: performanceCoreCount
+        )
+    }
 
+    /// DarwinではmacOS/iOSともに最高性能クラスタを優先し、sysctl値を取得できない
+    /// 端末やDarwin以外では論理CPU数から安全なフォールバックを選ぶ。
+    static func selectInferenceThreadCount(
+        activeProcessorCount: Int,
+        performanceCoreCount: Int?
+    ) -> Int {
+        let activeProcessorCount = max(1, activeProcessorCount)
+        if let performanceCoreCount,
+           performanceCoreCount > 0,
+           performanceCoreCount <= activeProcessorCount {
+            return performanceCoreCount
+        }
+        let reservedProcessorCount = if activeProcessorCount >= 8 {
+            2
+        } else if activeProcessorCount >= 4 {
+            1
+        } else {
+            0
+        }
+        return max(1, min(8, activeProcessorCount - reservedProcessorCount))
+    }
+
+    #if canImport(Darwin)
+    private static func sysctlInt32(_ name: String) -> Int? {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        guard sysctlbyname(name, &value, &size, nil, 0) == 0, size == MemoryLayout<Int32>.size else {
+            return nil
+        }
+        return Int(value)
+    }
+    #endif
+
+    static func createContext(path: String) throws -> ZenzContext {
+        let sharedModel = try SharedZenzModelCache.shared.model(path: path)
         var params = ctx_params
         #if ZenzaiCPU
         // CPU 専用: KV / KQV 等の GPU オフロードを完全に無効化
         params.offload_kqv = false
         #endif
-        let context = llama_init_from_model(model, params)
+        let context = llama_init_from_model(sharedModel.model, params)
         guard let context else {
             debug("Could not load context!")
             throw ZenzError.couldNotLoadContext
         }
 
-        let vocab = llama_model_get_vocab(model)
-        guard let vocab else {
-            debug("Could not load vocab!")
-            throw ZenzError.couldNotLoadVocab
-        }
-
-        return ZenzContext(model: model, context: context, vocab: vocab)
+        return ZenzContext(sharedModel: sharedModel, context: context)
     }
 
     func resetContext() throws {
@@ -96,7 +233,7 @@ final class ZenzContext {
         #if ZenzaiCPU
         params.offload_kqv = false
         #endif
-        let context = llama_init_from_model(self.model, params)
+        let context = llama_init_from_model(self.sharedModel.model, params)
         guard let context else {
             debug("Could not load context!")
             throw ZenzError.couldNotLoadContext
@@ -143,18 +280,17 @@ final class ZenzContext {
             llama_kv_cache_seq_rm(context, seqId, llama_pos(prefixCacheCount), -1)
             debug("new pos max:", llama_kv_cache_seq_pos_max(self.context, seqId), "commonTokens:", commonTokens.count)
         }
-        var batch = llama_batch_init(512, 0, 1)
-        defer { llama_batch_free(batch) }
+        self.batch.n_tokens = 0
         let n_ctx = llama_n_ctx(context)
         let n_kv_req = tokens.count + (Int(n_len) - tokens.count)
         if n_kv_req > n_ctx {
             debug("error: n_kv_req > n_ctx, the required KV cache size is not big enough")
         }
         for i in tokens.indices.dropFirst(prefixCacheCount) {
-            llama_batch_add(&batch, tokens[i], Int32(i), [seqId], logits: logits_start_index <= i)
+            llama_batch_add(&self.batch, tokens[i], Int32(i), [seqId], logits: logits_start_index <= i)
         }
         // 評価
-        if llama_decode(context, batch) != 0 {
+        if llama_decode(context, self.batch) != 0 {
             debug("llama_decode() failed")
             return nil
         }
@@ -163,16 +299,38 @@ final class ZenzContext {
         return llama_get_logits(context)
     }
 
-    func previousEvaluationPromptTokens() -> [llama_token] {
-        self.prevPromptBySeq[evalSeqId] ?? []
+    func previousEvaluationPrompt() -> String {
+        self.prevPromptBySeq[evalSeqId] ?? ""
     }
 
-    func setPreviousEvaluationPromptTokens(_ tokens: [llama_token]) {
-        self.prevPromptBySeq[evalSeqId] = tokens
+    func setPreviousEvaluationPrompt(_ prompt: String) {
+        self.prevPromptBySeq[evalSeqId] = prompt
+    }
+
+    func cachedEvaluation(for key: ZenzEvaluationCacheKey) -> CandidateEvaluationResult? {
+        self.sharedModel.evaluationCache.value(for: key)
+    }
+
+    func cacheEvaluation(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
+        self.sharedModel.evaluationCache.insert(result, for: key)
     }
 
     func normalizeForModel(_ text: String) -> String {
         self.preprocessText(text: text)
+    }
+
+    func encodeEvaluationPrompt(_ prompt: String) -> [llama_token] {
+        if let cached = self.evaluationPromptTokenCache, cached.prompt == prompt {
+            return cached.tokens
+        }
+        if let cached = self.sharedModel.evaluationPromptTokenCache.object(forKey: prompt as NSString) {
+            self.evaluationPromptTokenCache = (prompt, cached.tokens)
+            return cached.tokens
+        }
+        let tokens = self.encode(prompt, addBOS: true, addEOS: false)
+        self.evaluationPromptTokenCache = (prompt, tokens)
+        self.sharedModel.evaluationPromptTokenCache.setObject(ZenzTokenArrayBox(tokens), forKey: prompt as NSString)
+        return tokens
     }
 
     func encode(_ text: String, addBOS: Bool, addEOS: Bool = false) -> [llama_token] {
@@ -192,11 +350,11 @@ final class ZenzContext {
     }
 
     var vocabSize: Int {
-        Int(llama_vocab_n_tokens(vocab))
+        Int(llama_vocab_n_tokens(self.sharedModel.vocab))
     }
 
     var eosToken: llama_token {
-        llama_vocab_eos(vocab)
+        llama_vocab_eos(self.sharedModel.vocab)
     }
 
     func decodeTokens(_ tokens: [llama_token]) -> String {
@@ -225,15 +383,15 @@ final class ZenzContext {
         let utf8Count = text.utf8.count
         let n_tokens = utf8Count + (add_bos ? 1 : 0)
         let tokens = UnsafeMutablePointer<llama_token>.allocate(capacity: n_tokens)
-        let tokenCount = llama_tokenize(vocab, text, Int32(utf8Count), tokens, Int32(n_tokens), add_bos, false)
+        let tokenCount = llama_tokenize(self.sharedModel.vocab, text, Int32(utf8Count), tokens, Int32(n_tokens), add_bos, false)
         var swiftTokens: [llama_token] = if tokenCount < 0 {
-            [llama_vocab_bos(vocab)]
+            [llama_vocab_bos(self.sharedModel.vocab)]
         } else {
             (0..<tokenCount).map {tokens[Int($0)]}
         }
         tokens.deallocate()
         if add_eos {
-            swiftTokens.append(llama_vocab_eos(vocab))
+            swiftTokens.append(llama_vocab_eos(self.sharedModel.vocab))
         }
         return swiftTokens
     }
@@ -245,7 +403,7 @@ final class ZenzContext {
         defer {
             result.deallocate()
         }
-        let nTokens = llama_token_to_piece(vocab, token, result, 8, 0, false)
+        let nTokens = llama_token_to_piece(self.sharedModel.vocab, token, result, 8, 0, false)
 
         if nTokens < 0 {
             let newResult = UnsafeMutablePointer<Int8>.allocate(capacity: Int(-nTokens))
@@ -253,7 +411,7 @@ final class ZenzContext {
             defer {
                 newResult.deallocate()
             }
-            let nNewTokens = llama_token_to_piece(vocab, token, newResult, Int32(-nTokens), 0, false)
+            let nNewTokens = llama_token_to_piece(self.sharedModel.vocab, token, newResult, Int32(-nTokens), 0, false)
             let bufferPointer: UnsafeBufferPointer<Int8> = UnsafeBufferPointer(start: newResult, count: Int(nNewTokens))
             return Array(bufferPointer)
         } else {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -30,6 +30,11 @@ enum ZenzError: LocalizedError {
 /// コンテキストより先に解放される可能性があるプロセス終了時の明示解放は行わない。
 private enum ZenzBackend {
     private static let initialized: Void = {
+        #if ZenzaiCPU && canImport(Darwin)
+        // llama.cpp b9637ではbackend registry生成時にMetalも初期化される。
+        // CPU推論ではMetal shaderの初期ロードを避ける。
+        setenv("GGML_DISABLE_METAL", "1", 0)
+        #endif
         llama_backend_init()
     }()
 
@@ -237,13 +242,22 @@ final class ZenzContext {
         debug("Using \(n_threads) threads")
         var ctx_params = llama_context_default_params()
         ctx_params.n_ctx = 512
+        #if os(Linux) || os(Windows)
+        ctx_params.flash_attn = true
+        #else
+        // 評価用(0)と入力予測用(1)の2 sequenceを同一KV cacheで扱う。
+        ctx_params.n_seq_max = 2
+        // 両sequenceはpromptの大部分を共有する。512 tokenの総容量を分割せず、
+        // 従来と同じ容量のKV cacheとして共有する。
+        ctx_params.kv_unified = true
+        ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED
+        #endif
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
         #if Zenzai || ZenzaiCPU
         ctx_params.n_ubatch = 64
         #endif
-        ctx_params.flash_attn = true
         // 推論時間は呼び出し側で計測する。llama.cpp内部の統計更新は不要。
         ctx_params.no_perf = true
         return ctx_params
@@ -334,6 +348,9 @@ final class ZenzContext {
     }
 
     private func getLogits(tokens: [llama_token], logits_start_index: Int = 0, seqId: llama_seq_id = 0) -> UnsafeMutablePointer<Float>? {
+        #if !os(Linux) && !os(Windows)
+        let memory = llama_get_memory(self.context)
+        #endif
         let currentPrevInput = self.prevInputBySeq[seqId] ?? []
         var effectivePrevInput = currentPrevInput
 
@@ -351,8 +368,13 @@ final class ZenzContext {
             if otherPrefix > currentPrefix {
                 let copiedPrefixCount = min(otherPrefix, logits_start_index)
                 if copiedPrefixCount > 0 {
+                    #if os(Linux) || os(Windows)
                     llama_kv_cache_seq_rm(context, seqId, 0, -1)
                     llama_kv_cache_seq_cp(context, otherSeqId, seqId, 0, llama_pos(copiedPrefixCount))
+                    #else
+                    llama_memory_seq_rm(memory, seqId, 0, -1)
+                    llama_memory_seq_cp(memory, otherSeqId, seqId, 0, llama_pos(copiedPrefixCount))
+                    #endif
                     effectivePrevInput = otherPrevInput
                 }
             }
@@ -361,14 +383,23 @@ final class ZenzContext {
         // Manage KV cache: remove entries that differ from previous input
         let prefixCacheCount: Int
         do {
+            #if os(Linux) || os(Windows)
             let pos_max = llama_kv_cache_seq_pos_max(self.context, seqId)
+            #else
+            let pos_max = llama_memory_seq_pos_max(memory, seqId)
+            #endif
             debug("pos max:", pos_max, "prevInput count:", effectivePrevInput.count, "tokens count:", tokens.count)
             let commonTokens = effectivePrevInput.commonPrefix(with: tokens)
             // Remove KV cache from position commonTokens.count onwards to recompute divergent part
             // removed range: [llama_pos(commonTokens.count), inf)
             prefixCacheCount = min(commonTokens.count, logits_start_index)
+            #if os(Linux) || os(Windows)
             llama_kv_cache_seq_rm(context, seqId, llama_pos(prefixCacheCount), -1)
             debug("new pos max:", llama_kv_cache_seq_pos_max(self.context, seqId), "commonTokens:", commonTokens.count)
+            #else
+            llama_memory_seq_rm(memory, seqId, llama_pos(prefixCacheCount), -1)
+            debug("new pos max:", llama_memory_seq_pos_max(memory, seqId), "commonTokens:", commonTokens.count)
+            #endif
         }
         self.batch.n_tokens = 0
         let n_ctx = llama_n_ctx(context)

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -46,6 +46,89 @@ private final class ZenzTokenArrayBox {
     let tokens: [llama_token]
 }
 
+struct ZenzResolvedConversionCacheKey: Equatable, Hashable {
+    var dictionaryIdentifier: ObjectIdentifier
+    var input: [ComposingText.InputElement]
+    var convertTarget: String
+    var convertTargetCursorPosition: Int?
+    var keyboardLanguage: KeyboardLanguage
+    var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+}
+
+struct ZenzResolvedConversion {
+    var resultPrevs: [RegisteredNode]
+    var resultLatticeHead: ZenzResolvedLatticeHead
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+    var satisfyingCandidate: Candidate
+}
+
+struct ZenzResolvedLatticeNode: Hashable {
+    var data: DicdataElement
+    var range: Lattice.LatticeRange
+}
+
+final class ZenzResolvedLatticeHead: @unchecked Sendable {
+    init(nodes: [ZenzResolvedLatticeNode]) {
+        self.nodes = nodes
+        self.fingerprint = nodes.hashValue
+    }
+
+    let nodes: [ZenzResolvedLatticeNode]
+    let fingerprint: Int
+}
+
+private final class ZenzResolvedConversionCache: @unchecked Sendable {
+    private struct Entry {
+        var value: ZenzResolvedConversion
+        var accessIndex: UInt64
+    }
+
+    init(capacity: Int) {
+        self.capacity = capacity
+    }
+
+    func value(for key: ZenzResolvedConversionCacheKey) -> ZenzResolvedConversion? {
+        self.lock.withLock {
+            guard var entry = self.entries[key] else {
+                return nil
+            }
+            self.accessIndex &+= 1
+            entry.accessIndex = self.accessIndex
+            self.entries[key] = entry
+            return entry.value
+        }
+    }
+
+    func insert(_ value: ZenzResolvedConversion, for key: ZenzResolvedConversionCacheKey) {
+        var value = value
+        self.lock.withLock {
+            // 逐次入力では最大辞書長を超えた後の先頭候補が同一になる。
+            // 不変配列を既存entryと共有し、prefixごとの重複保持を避ける。
+            if let sharedHead = self.entries.values.lazy.map({
+                $0.value.resultLatticeHead
+            }).first(where: {
+                $0.fingerprint == value.resultLatticeHead.fingerprint
+                    && $0.nodes == value.resultLatticeHead.nodes
+            }) {
+                value.resultLatticeHead = sharedHead
+            }
+            self.accessIndex &+= 1
+            self.entries[key] = Entry(value: value, accessIndex: self.accessIndex)
+            if self.entries.count > self.capacity,
+               let oldestKey = self.entries.min(by: {
+                   $0.value.accessIndex < $1.value.accessIndex
+               })?.key {
+                self.entries.removeValue(forKey: oldestKey)
+            }
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [ZenzResolvedConversionCacheKey: Entry] = [:]
+    private var accessIndex: UInt64 = 0
+    private let lock = NSLock()
+}
+
 /// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
 ///
 /// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
@@ -84,6 +167,7 @@ private final class SharedZenzModel {
         self.model = model
         self.vocab = vocab
         self.evaluationCache = ZenzEvaluationCache(capacity: 256)
+        self.resolvedConversionCache = ZenzResolvedConversionCache(capacity: 64)
         self.evaluationPromptTokenCache.countLimit = 128
     }
 
@@ -94,6 +178,7 @@ private final class SharedZenzModel {
     let model: OpaquePointer
     let vocab: OpaquePointer
     let evaluationCache: ZenzEvaluationCache
+    fileprivate let resolvedConversionCache: ZenzResolvedConversionCache
     let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
 }
 
@@ -155,6 +240,9 @@ final class ZenzContext {
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
+        #if Zenzai || ZenzaiCPU
+        ctx_params.n_ubatch = 64
+        #endif
         ctx_params.flash_attn = true
         return ctx_params
     }
@@ -313,6 +401,19 @@ final class ZenzContext {
 
     func cacheEvaluation(_ result: CandidateEvaluationResult, for key: ZenzEvaluationCacheKey) {
         self.sharedModel.evaluationCache.insert(result, for: key)
+    }
+
+    func cachedResolvedConversion(
+        for key: ZenzResolvedConversionCacheKey
+    ) -> ZenzResolvedConversion? {
+        self.sharedModel.resolvedConversionCache.value(for: key)
+    }
+
+    func cacheResolvedConversion(
+        _ value: ZenzResolvedConversion,
+        for key: ZenzResolvedConversionCacheKey
+    ) {
+        self.sharedModel.resolvedConversionCache.insert(value, for: key)
     }
 
     func normalizeForModel(_ text: String) -> String {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -60,6 +60,21 @@ struct ZenzResolvedConversionCacheKey: Equatable, Hashable {
     var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
 }
 
+struct ZenzDraftConversionCacheKey: Equatable, Hashable {
+    var dictionaryIdentifier: ObjectIdentifier
+    var input: [ComposingText.InputElement]
+    var convertTarget: String
+    var convertTargetCursorPosition: Int?
+    var keyboardLanguage: KeyboardLanguage
+    var versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode
+    var prefixConstraint: Kana2Kanji.PrefixConstraint
+}
+
+struct ZenzDraftConversion {
+    var resultPrevs: [RegisteredNode]
+    var resultLatticeHead: ZenzResolvedLatticeHead
+}
+
 struct ZenzResolvedConversion {
     var resultPrevs: [RegisteredNode]
     var resultLatticeHead: ZenzResolvedLatticeHead
@@ -134,6 +149,56 @@ private final class ZenzResolvedConversionCache: @unchecked Sendable {
     private let lock = NSLock()
 }
 
+/// 同じ辞書状態・入力・制約から得た不変のdraft経路を共有するLRU cache。
+/// 可変な探索状態を含むlattice本体は保持しない。
+final class ZenzDraftConversionCache: @unchecked Sendable {
+    private struct Entry {
+        var value: ZenzDraftConversion
+        var accessIndex: UInt64
+    }
+
+    init(capacity: Int) {
+        self.capacity = capacity
+    }
+
+    func value(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.lock.withLock {
+            guard var entry = self.entries[key] else { return nil }
+            self.accessIndex &+= 1
+            entry.accessIndex = self.accessIndex
+            self.entries[key] = entry
+            return entry.value
+        }
+    }
+
+    func insert(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
+        var value = value
+        self.lock.withLock {
+            if let sharedHead = self.entries.values.lazy.map({
+                $0.value.resultLatticeHead
+            }).first(where: {
+                $0.fingerprint == value.resultLatticeHead.fingerprint
+                    && $0.nodes == value.resultLatticeHead.nodes
+            }) {
+                value.resultLatticeHead = sharedHead
+            }
+            self.accessIndex &+= 1
+            self.entries[key] = Entry(value: value, accessIndex: self.accessIndex)
+            if self.entries.count > self.capacity,
+               let oldestKey = self.entries.min(by: {
+                   $0.value.accessIndex < $1.value.accessIndex
+               })?.key {
+                self.entries.removeValue(forKey: oldestKey)
+            }
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [ZenzDraftConversionCacheKey: Entry] = [:]
+    private var accessIndex: UInt64 = 0
+    private let lock = NSLock()
+}
+
 /// 読み取り専用のGGUFモデルを複数の推論コンテキスト間で共有する。
 ///
 /// KV cacheなどの可変状態は`ZenzContext`側に残し、モデルの重みとvocabularyだけを
@@ -178,6 +243,7 @@ private final class SharedZenzModel {
         self.vocab = vocab
         self.evaluationCache = ZenzEvaluationCache(capacity: 256)
         self.resolvedConversionCache = ZenzResolvedConversionCache(capacity: 64)
+        self.draftConversionCache = ZenzDraftConversionCache(capacity: 128)
         self.evaluationPromptTokenCache.countLimit = 128
     }
 
@@ -189,6 +255,7 @@ private final class SharedZenzModel {
     let vocab: OpaquePointer
     let evaluationCache: ZenzEvaluationCache
     fileprivate let resolvedConversionCache: ZenzResolvedConversionCache
+    fileprivate let draftConversionCache: ZenzDraftConversionCache
     let evaluationPromptTokenCache = NSCache<NSString, ZenzTokenArrayBox>()
 }
 
@@ -452,6 +519,14 @@ final class ZenzContext {
         for key: ZenzResolvedConversionCacheKey
     ) {
         self.sharedModel.resolvedConversionCache.insert(value, for: key)
+    }
+
+    func cachedDraftConversion(for key: ZenzDraftConversionCacheKey) -> ZenzDraftConversion? {
+        self.sharedModel.draftConversionCache.value(for: key)
+    }
+
+    func cacheDraftConversion(_ value: ZenzDraftConversion, for key: ZenzDraftConversionCacheKey) {
+        self.sharedModel.draftConversionCache.insert(value, for: key)
     }
 
     func normalizeForModel(_ text: String) -> String {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -14,6 +14,7 @@ package struct llama_context_params {
     package var n_threads: Int32
     package var n_threads_batch: Int32
     package var n_batch: Int
+    package var flash_attn: Bool
 }
 package func llama_context_default_params() -> llama_context_params { unimplemented() }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -36,6 +36,7 @@ package func llama_backend_free() {}
 
 package struct llama_model_params {
     package var use_mmap: Bool
+    package var use_extra_bufts: Bool
 }
 package func llama_model_default_params() -> llama_model_params { unimplemented() }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -11,10 +11,14 @@ package typealias llama_seq_id = Int32
 package struct llama_context_params {
     package var seed: Int
     package var n_ctx: Int
+    package var n_seq_max: Int
+    package var kv_unified: Bool
     package var n_threads: Int32
     package var n_threads_batch: Int32
     package var n_batch: Int
     package var flash_attn: Bool
+    package var flash_attn_type: Int32
+    package var no_perf: Bool
 }
 package func llama_context_default_params() -> llama_context_params { unimplemented() }
 
@@ -42,6 +46,13 @@ package func llama_model_load_from_file(_: String, _: llama_model_params) -> lla
 package func llama_kv_cache_seq_rm(_: llama_context, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
 package func llama_kv_cache_seq_cp(_: llama_context, _: llama_seq_id, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
 package func llama_kv_cache_seq_pos_max(_: llama_context, _: llama_seq_id) -> Int { unimplemented() }
+
+package let LLAMA_FLASH_ATTN_TYPE_ENABLED: Int32 = 1
+package typealias llama_memory = OpaquePointer
+package func llama_get_memory(_: llama_context) -> llama_memory { unimplemented() }
+package func llama_memory_seq_rm(_: llama_memory, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
+package func llama_memory_seq_cp(_: llama_memory, _: llama_seq_id, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
+package func llama_memory_seq_pos_max(_: llama_memory, _: llama_seq_id) -> Int { unimplemented() }
 
 package struct llama_batch {
     package var token: [llama_token]

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -114,6 +114,7 @@ extension Kana2Kanji {
         _ inputData: ComposingText,
         zenz: Zenz,
         zenzaiCache: ZenzaiCache?,
+        zenzaiSessionCache: ZenzaiSessionCache,
         inferenceLimit: Int,
         requestRichCandidates: Bool,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
@@ -129,23 +130,27 @@ extension Kana2Kanji {
                 composingText: inputData,
                 inputStyle: inputStyle
             ).droppedSuffixCount > 0
+        var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
         let resolvedConversionCacheKey: ZenzResolvedConversionCacheKey? =
             if !requestRichCandidates,
                personalizationMode == nil,
                dicdataStoreState.canShareStaticConversionResults() {
                 ZenzResolvedConversionCacheKey(
-                    dictionaryIdentifier: ObjectIdentifier(self.dicdataStore),
                     input: latticeInputData.input,
                     convertTarget: latticeInputData.convertTarget,
                     convertTargetCursorPosition: zenzInputCursorPosition,
                     keyboardLanguage: dicdataStoreState.keyboardLanguage,
-                    versionDependentConfig: versionDependentConfig
+                    versionDependentConfig: versionDependentConfig,
+                    prefixConstraint: constraint,
+                    inferenceLimit: inferenceLimit
                 )
             } else {
                 nil
-            }
+        }
         if let resolvedConversionCacheKey,
-           let cached = zenz.cachedResolvedConversion(for: resolvedConversionCacheKey) {
+           let cached = zenzaiSessionCache.cachedResolvedConversion(
+               for: resolvedConversionCacheKey
+           ) {
             // 全文経路とは別にprocessResultが参照する先頭辞書ノードだけを復元する。
             // 可変な探索状態を持つラティス本体は共有しない。
             let lattice = Lattice(
@@ -174,7 +179,6 @@ extension Kana2Kanji {
                 nextCache
             )
         }
-        var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
@@ -206,7 +210,6 @@ extension Kana2Kanji {
                                                                  personalizationMode == nil,
                                                                  dicdataStoreState.canShareStaticConversionResults() {
                 ZenzDraftConversionCacheKey(
-                    dictionaryIdentifier: ObjectIdentifier(self.dicdataStore),
                     input: latticeInputData.input,
                     convertTarget: latticeInputData.convertTarget,
                     convertTargetCursorPosition: zenzInputCursorPosition,
@@ -217,7 +220,9 @@ extension Kana2Kanji {
             } else {
                 nil
             }
-            let cachedDraft = draftCacheKey.flatMap { zenz.cachedDraftConversion(for: $0) }
+            let cachedDraft = draftCacheKey.flatMap {
+                zenzaiSessionCache.cachedDraftConversion(for: $0)
+            }
             let preprocessedLattice: Lattice?
             if cachedDraft != nil {
                 preprocessedLattice = nil
@@ -271,7 +276,7 @@ extension Kana2Kanji {
                 )
             }
             if let draftCacheKey, cachedDraft == nil {
-                zenz.cacheDraftConversion(
+                zenzaiSessionCache.cacheDraftConversion(
                     ZenzDraftConversion(
                         resultPrevs: draftResult.result.prevs,
                         resultLatticeHead: ZenzResolvedLatticeHead(
@@ -334,7 +339,8 @@ extension Kana2Kanji {
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: constraint,
                     personalizationMode: personalizationMode,
-                    versionDependentConfig: versionDependentConfig
+                    versionDependentConfig: versionDependentConfig,
+                    sessionCache: zenzaiSessionCache
                 )
                 inferenceLimit -= 1
                 let nextAction = self.review(
@@ -395,7 +401,7 @@ extension Kana2Kanji {
                                    )
                                }
                            }) {
-                            zenz.cacheResolvedConversion(
+                            zenzaiSessionCache.cacheResolvedConversion(
                                 ZenzResolvedConversion(
                                     resultPrevs: insertedCandidates.map(\.0),
                                     resultLatticeHead: ZenzResolvedLatticeHead(

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -10,12 +10,44 @@ extension Kana2Kanji {
             self.prefixConstraint = constraint
             self.satisfyingCandidate = satisfyingCandidate
             self.cachedLattice = lattice
+            self.cachedLatticeInputData = lattice == nil ? nil : inputData
+        }
+
+        private init(
+            _ inputData: ComposingText,
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate?,
+            cachedLattice: Lattice?,
+            cachedLatticeInputData: ComposingText?
+        ) {
+            self.inputData = inputData
+            self.prefixConstraint = constraint
+            self.satisfyingCandidate = satisfyingCandidate
+            self.cachedLattice = cachedLattice
+            self.cachedLatticeInputData = cachedLatticeInputData
         }
 
         private var prefixConstraint: PrefixConstraint
         private var satisfyingCandidate: Candidate?
         private var inputData: ComposingText
         private var cachedLattice: Lattice?
+        private var cachedLatticeInputData: ComposingText?
+
+        /// 共有済みの変換結果を使う場合、現在の制約だけを更新し、直近の完全な
+        /// ラティスは次の未キャッシュ入力の差分構築用アンカーとして保持する。
+        func updatingResult(
+            for newInputData: ComposingText,
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate
+        ) -> ZenzaiCache {
+            ZenzaiCache(
+                newInputData,
+                constraint: constraint,
+                satisfyingCandidate: satisfyingCandidate,
+                cachedLattice: self.cachedLattice,
+                cachedLatticeInputData: self.cachedLatticeInputData
+            )
+        }
 
         func getNewConstraint(for newInputData: ComposingText) -> PrefixConstraint {
             if let satisfyingCandidate {
@@ -37,10 +69,11 @@ extension Kana2Kanji {
         }
 
         func getPreprocessedLattice(for newInputData: ComposingText, kanaKanji: Kana2Kanji, dicdataStoreState: DicdataStoreState) -> Lattice? {
-            guard let cachedLattice else { return nil }
+            guard let cachedLattice, let cachedLatticeInputData else { return nil }
 
             // 同じComposingTextなら既存のlatticeをそのまま返す
-            if newInputData.input == inputData.input && newInputData.convertTarget == inputData.convertTarget {
+            if newInputData.input == cachedLatticeInputData.input
+                && newInputData.convertTarget == cachedLatticeInputData.convertTarget {
                 cachedLattice.resetNodeStates()
                 return cachedLattice
             }
@@ -50,7 +83,7 @@ extension Kana2Kanji {
                 inputData: newInputData,
                 inputCount: newInputData.input.count,
                 surfaceCount: newInputData.convertTarget.count,
-                incrementalCacheInfo: (inputData: inputData, lattice: cachedLattice),
+                incrementalCacheInfo: (inputData: cachedLatticeInputData, lattice: cachedLattice),
                 dicdataStoreState: dicdataStoreState
             )
         }
@@ -89,12 +122,81 @@ extension Kana2Kanji {
     ) -> (result: LatticeNode, lattice: Lattice, cache: ZenzaiCache) {
         let latticeInputData = Self.zenzaiLatticeInputData(for: inputData)
         let zenzInputCursorPosition = Self.zenzaiInputCursorPosition(for: inputData)
+        let inputStyle = inputData.input.last?.inputStyle ?? .direct
+        let defersEvaluationForPendingInput = !requestRichCandidates
+            && personalizationMode == nil
+            && self.resolvePredictiveInputSource(
+                composingText: inputData,
+                inputStyle: inputStyle
+            ).droppedSuffixCount > 0
+        let resolvedConversionCacheKey: ZenzResolvedConversionCacheKey? =
+            if !requestRichCandidates,
+               personalizationMode == nil,
+               dicdataStoreState.canShareStaticConversionResults() {
+                ZenzResolvedConversionCacheKey(
+                    dictionaryIdentifier: ObjectIdentifier(self.dicdataStore),
+                    input: latticeInputData.input,
+                    convertTarget: latticeInputData.convertTarget,
+                    convertTargetCursorPosition: zenzInputCursorPosition,
+                    keyboardLanguage: dicdataStoreState.keyboardLanguage,
+                    versionDependentConfig: versionDependentConfig
+                )
+            } else {
+                nil
+            }
+        if let resolvedConversionCacheKey,
+           let cached = zenz.cachedResolvedConversion(for: resolvedConversionCacheKey) {
+            // 全文経路とは別にprocessResultが参照する先頭辞書ノードだけを復元する。
+            // 可変な探索状態を持つラティス本体は共有しない。
+            let lattice = Lattice(
+                inputCount: latticeInputData.input.count,
+                surfaceCount: latticeInputData.convertTarget.count,
+                rawNodes: [
+                    cached.resultLatticeHead.nodes.map {
+                        LatticeNode(data: $0.data, range: $0.range)
+                    }
+                ]
+            )
+            let eosNode = LatticeNode.EOSNode
+            eosNode.prevs = cached.resultPrevs
+            let nextCache = zenzaiCache?.updatingResult(
+                for: latticeInputData,
+                constraint: cached.prefixConstraint,
+                satisfyingCandidate: cached.satisfyingCandidate
+            ) ?? ZenzaiCache(
+                latticeInputData,
+                constraint: cached.prefixConstraint,
+                satisfyingCandidate: cached.satisfyingCandidate
+            )
+            return (
+                eosNode,
+                lattice,
+                nextCache
+            )
+        }
         var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
+        let incrementalPrefixConstraint: PrefixConstraint? = if zenzaiCache != nil,
+                                                                inputData.input.last?.inputStyle == .direct {
+            constraint
+        } else {
+            nil
+        }
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
         var constructedCandidates: [(RegisteredNode, Candidate)] = []
         var insertedCandidates: [(RegisteredNode, Candidate)] = []
+        func makeCache(
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate?
+        ) -> ZenzaiCache {
+            ZenzaiCache(
+                latticeInputData,
+                constraint: constraint,
+                satisfyingCandidate: satisfyingCandidate,
+                lattice: lattice
+            )
+        }
         defer {
             eosNode.prevs = insertedCandidates.map(\.0)
         }
@@ -116,8 +218,16 @@ extension Kana2Kanji {
                 // 実験の結果、ここは2-bestを取ると平均的な速度が最良になることがわかったので、そうしている。
                 draftResult = self.kana2lattice_all(latticeInputData, N_best: 2, needTypoCorrection: false, preprocessedLattice: preprocessedLattice, dicdataStoreState: dicdataStoreState)
             } else {
-                // 制約がついている場合は高速になるので、N=3としている
-                draftResult = self.kana2lattice_all_with_prefix_constraint(latticeInputData, N_best: 3, constraint: constraint, preprocessedLattice: preprocessedLattice, dicdataStoreState: dicdataStoreState)
+                // rich候補を要求しない通常モードでは最良経路しか消費しない。
+                // rich候補用の代替制約探索では従来どおり3-bestを保持する。
+                let constrainedNBest = requestRichCandidates ? 3 : 1
+                draftResult = self.kana2lattice_all_with_prefix_constraint(
+                    latticeInputData,
+                    N_best: constrainedNBest,
+                    constraint: constraint,
+                    preprocessedLattice: preprocessedLattice,
+                    dicdataStoreState: dicdataStoreState
+                )
             }
             if lattice.isEmpty {
                 // 初回のみ
@@ -137,7 +247,7 @@ extension Kana2Kanji {
                 debug("best was not found!")
                 // Emptyの場合
                 // 制約が満たせない場合は無視する
-                return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: PrefixConstraint([]), satisfyingCandidate: nil, lattice: lattice))
+                return (eosNode, lattice, makeCache(constraint: PrefixConstraint([]), satisfyingCandidate: nil))
             }
 
             debug("Constrained draft modeling", -start.timeIntervalSinceNow)
@@ -148,7 +258,17 @@ extension Kana2Kanji {
                 if inferenceLimit == 0 {
                     debug("inference limit! \(candidate.text) is used for excuse")
                     // When inference occurs more than maximum times, then just return result at this point
-                    return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: constraint, satisfyingCandidate: candidate, lattice: lattice))
+                    return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: candidate))
+                }
+                if defersEvaluationForPendingInput {
+                    // ローマ字表で未確定のsuffixは、次のキーでかなへ置換される。
+                    // モデルが未確定ASCIIを評価しても結果を再利用できないため、
+                    // かな列が確定するまで辞書変換結果を保持する。
+                    return (
+                        eosNode,
+                        lattice,
+                        makeCache(constraint: constraint, satisfyingCandidate: candidate)
+                    )
                 }
                 let reviewResult = zenz.candidateEvaluate(
                     convertTarget: inputData.convertTarget,
@@ -156,6 +276,7 @@ extension Kana2Kanji {
                     candidates: [candidate],
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: constraint,
+                    incrementalPrefixConstraint: incrementalPrefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig
                 )
@@ -204,9 +325,36 @@ extension Kana2Kanji {
                         }
                     }
                     if satisfied {
-                        return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: constraint, satisfyingCandidate: candidate, lattice: lattice))
+                        if let resolvedConversionCacheKey,
+                           insertedCandidates.allSatisfy({
+                               $0.1.data.allSatisfy {
+                                   $0.metadata.isDisjoint(
+                                       with: [.isLearned, .isFromUserDictionary]
+                                   )
+                               }
+                           }) {
+                            zenz.cacheResolvedConversion(
+                                ZenzResolvedConversion(
+                                    resultPrevs: insertedCandidates.map(\.0),
+                                    resultLatticeHead: ZenzResolvedLatticeHead(
+                                        nodes: lattice[
+                                            index: .bothIndex(inputIndex: 0, surfaceIndex: 0)
+                                        ].map {
+                                            ZenzResolvedLatticeNode(
+                                                data: $0.data,
+                                                range: $0.range
+                                            )
+                                        }
+                                    ),
+                                    prefixConstraint: constraint,
+                                    satisfyingCandidate: candidate
+                                ),
+                                for: resolvedConversionCacheKey
+                            )
+                        }
+                        return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: candidate))
                     } else {
-                        return (eosNode, lattice, ZenzaiCache(latticeInputData, constraint: constraint, satisfyingCandidate: nil, lattice: lattice))
+                        return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: nil))
                     }
                 case .continue:
                     break reviewLoop

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -175,12 +175,6 @@ extension Kana2Kanji {
             )
         }
         var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
-        let incrementalPrefixConstraint: PrefixConstraint? = if zenzaiCache != nil,
-                                                                inputData.input.last?.inputStyle == .direct {
-            constraint
-        } else {
-            nil
-        }
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
@@ -276,7 +270,6 @@ extension Kana2Kanji {
                     candidates: [candidate],
                     requestRichCandidates: requestRichCandidates,
                     prefixConstraint: constraint,
-                    incrementalPrefixConstraint: incrementalPrefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig
                 )

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -178,6 +178,7 @@ extension Kana2Kanji {
         debug("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var lattice: Lattice = Lattice()
+        var latticeIsComplete = true
         var constructedCandidates: [(RegisteredNode, Candidate)] = []
         var insertedCandidates: [(RegisteredNode, Candidate)] = []
         func makeCache(
@@ -188,29 +189,75 @@ extension Kana2Kanji {
                 latticeInputData,
                 constraint: constraint,
                 satisfyingCandidate: satisfyingCandidate,
-                lattice: lattice
+                lattice: latticeIsComplete ? lattice : nil
             )
         }
         defer {
             eosNode.prevs = insertedCandidates.map(\.0)
         }
         var inferenceLimit = inferenceLimit
+        var draftIteration = 0
         while true {
             let start = Date()
+            // 学習・ユーザ辞書・personalizationの影響がなく、入力と制約が完全一致する
+            // 初回draftだけを共有する。後続draftは直前の探索状態に依存するため対象外。
+            let draftCacheKey: ZenzDraftConversionCacheKey? = if draftIteration == 0,
+                                                                 !requestRichCandidates,
+                                                                 personalizationMode == nil,
+                                                                 dicdataStoreState.canShareStaticConversionResults() {
+                ZenzDraftConversionCacheKey(
+                    dictionaryIdentifier: ObjectIdentifier(self.dicdataStore),
+                    input: latticeInputData.input,
+                    convertTarget: latticeInputData.convertTarget,
+                    convertTargetCursorPosition: zenzInputCursorPosition,
+                    keyboardLanguage: dicdataStoreState.keyboardLanguage,
+                    versionDependentConfig: versionDependentConfig,
+                    prefixConstraint: constraint
+                )
+            } else {
+                nil
+            }
+            let cachedDraft = draftCacheKey.flatMap { zenz.cachedDraftConversion(for: $0) }
             let preprocessedLattice: Lattice?
-            if !lattice.isEmpty {
+            if cachedDraft != nil {
+                preprocessedLattice = nil
+            } else if !lattice.isEmpty {
                 // 今回の`all_zenzai`の呼び出し内部で使われているキャッシュ（lattice）が存在する場合はそちらを優先する
                 lattice.resetNodeStates()
                 preprocessedLattice = lattice
             } else {
                 // latticeがまだemptyの場合、zenzaiCache側に存在するキャッシュの活用を試みる
-                preprocessedLattice = zenzaiCache?.getPreprocessedLattice(for: latticeInputData, kanaKanji: self, dicdataStoreState: dicdataStoreState)
+                preprocessedLattice = zenzaiCache?.getPreprocessedLattice(
+                    for: latticeInputData,
+                    kanaKanji: self,
+                    dicdataStoreState: dicdataStoreState
+                )
             }
             let draftResult: (result: LatticeNode, lattice: Lattice)
-            if constraint.isEmpty {
-                // 全部を変換する場合はN=2の変換を行う
-                // 実験の結果、ここは2-bestを取ると平均的な速度が最良になることがわかったので、そうしている。
-                draftResult = self.kana2lattice_all(latticeInputData, N_best: 2, needTypoCorrection: false, preprocessedLattice: preprocessedLattice, dicdataStoreState: dicdataStoreState)
+            if let cachedDraft {
+                let cachedLattice = Lattice(
+                    inputCount: latticeInputData.input.count,
+                    surfaceCount: latticeInputData.convertTarget.count,
+                    rawNodes: [
+                        cachedDraft.resultLatticeHead.nodes.map {
+                            LatticeNode(data: $0.data, range: $0.range)
+                        }
+                    ]
+                )
+                let cachedResult = LatticeNode.EOSNode
+                cachedResult.prevs = cachedDraft.resultPrevs
+                draftResult = (cachedResult, cachedLattice)
+                // processResultが参照する先頭ノードだけを復元しているため、
+                // 後続draftのpreprocessed latticeとしては利用できない。
+                latticeIsComplete = false
+            } else if constraint.isEmpty {
+                draftResult = self.kana2lattice_all(
+                    latticeInputData,
+                    N_best: 2,
+                    needTypoCorrection: false,
+                    preprocessedLattice: preprocessedLattice,
+                    dicdataStoreState: dicdataStoreState
+                )
             } else {
                 // rich候補を要求しない通常モードでは最良経路しか消費しない。
                 // rich候補用の代替制約探索では従来どおり3-bestを保持する。
@@ -221,6 +268,21 @@ extension Kana2Kanji {
                     constraint: constraint,
                     preprocessedLattice: preprocessedLattice,
                     dicdataStoreState: dicdataStoreState
+                )
+            }
+            if let draftCacheKey, cachedDraft == nil {
+                zenz.cacheDraftConversion(
+                    ZenzDraftConversion(
+                        resultPrevs: draftResult.result.prevs,
+                        resultLatticeHead: ZenzResolvedLatticeHead(
+                            nodes: draftResult.lattice[
+                                index: .bothIndex(inputIndex: 0, surfaceIndex: 0)
+                            ].map {
+                                ZenzResolvedLatticeNode(data: $0.data, range: $0.range)
+                            }
+                        )
+                    ),
+                    for: draftCacheKey
                 )
             }
             if lattice.isEmpty {
@@ -237,6 +299,7 @@ extension Kana2Kanji {
                     best = (i, cand)
                 }
             }
+            draftIteration += 1
             guard var (index, candidate) = best else {
                 debug("best was not found!")
                 // Emptyの場合
@@ -302,7 +365,13 @@ extension Kana2Kanji {
                             } else if alternativeConstraint.probabilityRatio > 0.5 {
                                 // 十分に高い確率の場合、変換器を実際に呼び出して候補を作ってもらう
                                 lattice.resetNodeStates()
-                                let draftResult = self.kana2lattice_all_with_prefix_constraint(latticeInputData, N_best: 3, constraint: normalizedAlternativeConstraint, preprocessedLattice: lattice, dicdataStoreState: dicdataStoreState)
+                                let draftResult = self.kana2lattice_all_with_prefix_constraint(
+                                    latticeInputData,
+                                    N_best: 3,
+                                    constraint: normalizedAlternativeConstraint,
+                                    preprocessedLattice: lattice,
+                                    dicdataStoreState: dicdataStoreState
+                                )
                                 let candidates = draftResult.result.getCandidateData().map(self.processClauseCandidate)
                                 let best: (Int, Candidate)? = candidates.enumerated().reduce(into: (Int, Candidate)?.none) { best, pair in
                                     if let (_, c) = best, pair.1.value > c.value {
@@ -350,6 +419,10 @@ extension Kana2Kanji {
                         return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: nil))
                     }
                 case .continue:
+                    if !latticeIsComplete {
+                        lattice = Lattice()
+                        latticeIsComplete = true
+                    }
                     break reviewLoop
                 case .retry(let candidateIndex):
                     index = candidateIndex

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -203,7 +203,7 @@ public final class KanaKanjiConverter {
             return model
         } else {
             do {
-                self.zenz = try Zenz(resourceURL: modelURL)
+                self.zenz = try Zenz.shared(resourceURL: modelURL)
                 self.sessions = self.sessions.mapValues { state in
                     let next = state
                     next.zenzaiTypoCache.invalidateForModelChange()
@@ -1135,7 +1135,6 @@ public final class KanaKanjiConverter {
         guard let result = self.convertToLattice(inputData, N_best: options.N_best, zenzaiMode: options.zenzaiMode, needTypoCorrection: needTypoCorrection) else {
             return ConversionResult(mainResults: [], predictionResults: [], englishPredictionResults: [], firstClauseResults: [])
         }
-
         return self.processResult(inputData: inputData, result: result, options: options)
     }
 

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -19,6 +19,7 @@ public final class KanaKanjiConverter {
         var lattice: Lattice = .init()
         var completedData: Candidate?
         var zenzaiCache: Kana2Kanji.ZenzaiCache?
+        var zenzaiSessionCache: ZenzaiSessionCache = .init()
         var zenzaiTypoCache: ZenzaiTypoGenerationCache = .init()
         var ngramCache: NGramCache = .init()
         var predictiveInputCache: PredictiveInputCacheEntry?
@@ -72,7 +73,9 @@ public final class KanaKanjiConverter {
 
     private func withScratchSession<T>(_ body: () -> T) -> T {
         let scratchID: SessionID = "scratch-\(UUID().uuidString)"
-        self.sessions[scratchID] = self.currentSessionState
+        var scratchState = self.currentSessionState
+        scratchState.zenzaiSessionCache = .init()
+        self.sessions[scratchID] = scratchState
         let previousSessionID = self.activeSessionID
         let savedPersonalization = self.zenzaiPersonalization
         self.activeSessionID = scratchID
@@ -205,8 +208,9 @@ public final class KanaKanjiConverter {
             do {
                 self.zenz = try Zenz.shared(resourceURL: modelURL)
                 self.sessions = self.sessions.mapValues { state in
-                    let next = state
+                    var next = state
                     next.zenzaiTypoCache.invalidateForModelChange()
+                    next.zenzaiSessionCache = .init()
                     return next
                 }
                 self.zenzStatus = "load \(modelURL.absoluteString)"
@@ -1030,6 +1034,7 @@ public final class KanaKanjiConverter {
                 inputData,
                 zenz: model,
                 zenzaiCache: self.currentSessionState.zenzaiCache,
+                zenzaiSessionCache: self.currentSessionState.zenzaiSessionCache,
                 inferenceLimit: zenzaiMode.inferenceLimit,
                 requestRichCandidates: zenzaiMode.requestRichCandidates,
                 personalizationMode: self.getZenzaiPersonalization(mode: zenzaiMode.personalizationMode),

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/SpellChecker.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/SpellChecker.swift
@@ -15,6 +15,27 @@ import AppKit
 final class SpellChecker {
     init() {}
 
+    private final class CompletionCacheEntry {
+        init(_ completions: [String]?) {
+            self.completions = completions
+        }
+
+        let completions: [String]?
+    }
+
+    private final class CompletionCache: @unchecked Sendable {
+        init() {
+            self.storage.countLimit = 128
+            self.storage.totalCostLimit = 1 * 1024 * 1024
+        }
+
+        let storage = NSCache<NSString, CompletionCacheEntry>()
+    }
+
+    /// OSの補完器は同じ接頭辞に対しても比較的高コストなため、複数の変換器で共有する。
+    /// NSCacheによりメモリプレッシャー時は自動的に破棄される。
+    private static let completionCache = CompletionCache()
+
     #if os(iOS) || os(tvOS) || os(visionOS)
     // UITextChecker is main-actor isolated on iOS-family platforms.
     // Use a static instance to avoid capturing `self` in main-actor closures.
@@ -24,22 +45,45 @@ final class SpellChecker {
     #endif
 
     func completions(forPartialWordRange range: NSRange, in string: String, language: String) -> [String]? {
+        let cacheKey = "\(language)\u{0}\(range.location):\(range.length)\u{0}\(string)" as NSString
+        if let cached = Self.completionCache.storage.object(forKey: cacheKey) {
+            return cached.completions
+        }
+        let completions: [String]?
         #if os(iOS) || os(tvOS) || os(visionOS)
         if Thread.isMainThread {
             // Already on main thread: enter main-actor context synchronously.
-            return MainActor.assumeIsolated { Self.checker.completions(forPartialWordRange: range, in: string, language: language) }
+            completions = MainActor.assumeIsolated {
+                Self.checker.completions(
+                    forPartialWordRange: range,
+                    in: string,
+                    language: language
+                )
+            }
         } else {
             // Hop to main thread synchronously and run in main-actor context.
             var result: [String]?
             DispatchQueue.main.sync {
                 result = MainActor.assumeIsolated { Self.checker.completions(forPartialWordRange: range, in: string, language: language) }
             }
-            return result
+            completions = result
         }
         #elseif os(macOS)
-        return checker.completions(forPartialWordRange: range, in: string, language: language, inSpellDocumentWithTag: 0)
+        completions = checker.completions(
+            forPartialWordRange: range,
+            in: string,
+            language: language,
+            inSpellDocumentWithTag: 0
+        )
         #else
-        return nil
+        completions = nil
         #endif
+        let cost = completions?.reduce(32) { $0 + 16 + $1.utf8.count } ?? 16
+        Self.completionCache.storage.setObject(
+            CompletionCacheEntry(completions),
+            forKey: cacheKey,
+            cost: cost
+        )
+        return completions
     }
 }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DataStructure/LOUDS.swift
@@ -16,10 +16,11 @@ package struct LOUDS: Sendable {
 
     private let bits: [Unit]
     /// indexを並べてflattenしたArray。
+    /// LOUDS形式が4GB未満を前提としているため、64-bit環境でも`UInt32`で表現できる。
     ///  - seealso: flatChar2nodeIndicesIndex
-    private let flatChar2nodeIndices: [Int]
+    private let flatChar2nodeIndices: [UInt32]
     /// 256個の値を入れるArray。`flatChar2nodeIndices[flatChar2nodeIndicesIndex[char - 1] ..< flatChar2nodeIndicesIndex[char]]`が`nodeIndices`になる
-    private let flatChar2nodeIndicesIndex: [Int]
+    private let flatChar2nodeIndicesIndex: [UInt32]
     /// 0の数（1の数ではない）
     ///
     /// LOUDSのサイズが4GBまでは`UInt32`で十分
@@ -43,18 +44,18 @@ package struct LOUDS: Sendable {
         // すでに開始位置はflatChar2nodeIndicesIndexで分かるので、もう一度countsを構築しながら適切な場所にindexを入れていく
         var counts = [Int](repeating: 0, count: 256)
         self.flatChar2nodeIndices = counts.withUnsafeMutableBufferPointer { countsBuffer in
-            var flatChar2nodeIndices = [Int](repeating: 0, count: nodeIndex2ID.count)
+            var flatChar2nodeIndices = [UInt32](repeating: 0, count: nodeIndex2ID.count)
             for (i, value) in zip(nodeIndex2ID.indices, nodeIndex2ID) {
                 if value == .zero {
-                    flatChar2nodeIndices[countsBuffer[Int(value)]] = i
+                    flatChar2nodeIndices[countsBuffer[Int(value)]] = UInt32(i)
                 } else {
-                    flatChar2nodeIndices[flatChar2nodeIndicesIndex[Int(value) - 1] + countsBuffer[Int(value)]] = i
+                    flatChar2nodeIndices[flatChar2nodeIndicesIndex[Int(value) - 1] + countsBuffer[Int(value)]] = UInt32(i)
                 }
                 countsBuffer[Int(value)] += 1
             }
             return flatChar2nodeIndices
         }
-        self.flatChar2nodeIndicesIndex = flatChar2nodeIndicesIndex
+        self.flatChar2nodeIndicesIndex = flatChar2nodeIndicesIndex.map(UInt32.init)
 
         var rankLarge: [UInt32] = .init(repeating: 0, count: bytes.count + 1)
         rankLarge.withUnsafeMutableBufferPointer { buffer in
@@ -127,24 +128,28 @@ package struct LOUDS: Sendable {
     @inlinable func searchCharNodeIndex(from parentNodeIndex: Int, char: UInt8) -> Int? {
         // char2nodeIndicesには単調増加性があるので二分探索が成立する
         let childNodeIndices = self.childNodeIndices(from: parentNodeIndex)
-        let nodeIndices: ArraySlice<Int> = if char == .zero {
-            self.flatChar2nodeIndices[0 ..< self.flatChar2nodeIndicesIndex[Int(char)]]
+        let nodeIndices: ArraySlice<UInt32> = if char == .zero {
+            self.flatChar2nodeIndices[0 ..< Int(self.flatChar2nodeIndicesIndex[Int(char)])]
         } else {
-            self.flatChar2nodeIndices[self.flatChar2nodeIndicesIndex[Int(char - 1)] ..< self.flatChar2nodeIndicesIndex[Int(char)]]
+            self.flatChar2nodeIndices[
+                Int(self.flatChar2nodeIndicesIndex[Int(char - 1)]) ..< Int(self.flatChar2nodeIndicesIndex[Int(char)])
+            ]
         }
+        let childStart = UInt32(childNodeIndices.startIndex)
+        let childEnd = UInt32(childNodeIndices.endIndex)
 
         var left = nodeIndices.startIndex
         var right = nodeIndices.endIndex
         while left < right {
             let mid = (left + right) >> 1
-            if childNodeIndices.startIndex <= nodeIndices[mid] {
+            if childStart <= nodeIndices[mid] {
                 right = mid
             } else {
                 left = mid + 1
             }
         }
-        if left < nodeIndices.endIndex && childNodeIndices.contains(nodeIndices[left]) {
-            return nodeIndices[left]
+        if left < nodeIndices.endIndex && childStart <= nodeIndices[left] && nodeIndices[left] < childEnd {
+            return Int(nodeIndices[left])
         } else {
             return nil
         }

--- a/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStoreState.swift
+++ b/Sources/KanaKanjiConverterModule/DictionaryManagement/DicdataStoreState.swift
@@ -25,10 +25,12 @@ package final class DicdataStoreState {
 
     private(set) var memoryHasLoaded: Bool = false
     private(set) var memoryLOUDS: LOUDS?
+    private var staticConversionCacheEligibility: Bool?
 
     func updateUserDictionaryURL(_ newURL: URL, forceReload: Bool) {
         if self.userDictionaryURL != newURL || forceReload {
             self.userDictionaryURL = newURL
+            self.staticConversionCacheEligibility = nil
             self.userDictionaryLOUDS = nil
             self.userDictionaryHasLoaded = false
             self.userShortcutsLOUDS = nil
@@ -42,6 +44,7 @@ package final class DicdataStoreState {
 
     func updateLearningConfig(_ newConfig: LearningConfig) {
         if self.learningMemoryManager.config != newConfig {
+            self.staticConversionCacheEligibility = nil
             let updated = self.learningMemoryManager.updateConfig(newConfig)
             if updated {
                 self.resetMemoryLOUDSCache()
@@ -75,6 +78,7 @@ package final class DicdataStoreState {
     }
 
     func importDynamicUserDictionary(_ dicdata: [DicdataElement], shortcuts: [DicdataElement] = []) {
+        self.staticConversionCacheEligibility = nil
         self.dynamicUserDictionary = dicdata
         self.dynamicUserDictionary.mutatingForEach {
             $0.metadata = .isFromUserDictionary
@@ -83,6 +87,39 @@ package final class DicdataStoreState {
         self.dynamicUserShortcuts.mutatingForEach {
             $0.metadata = .isFromUserDictionary
         }
+    }
+
+    /// 辞書状態を跨いで変換結果を共有しても安全かを返す。
+    ///
+    /// 学習・動的辞書・永続ユーザ辞書のいずれかが有効な場合は、同じ入力でも
+    /// 候補列が変わり得るため共有しない。
+    func canShareStaticConversionResults() -> Bool {
+        if let staticConversionCacheEligibility {
+            return staticConversionCacheEligibility
+        }
+        guard self.learningMemoryManager.config.learningType == .nothing,
+              self.dynamicUserDictionary.isEmpty,
+              self.dynamicUserShortcuts.isEmpty else {
+            self.staticConversionCacheEligibility = false
+            return false
+        }
+        guard let userDictionaryURL else {
+            self.staticConversionCacheEligibility = true
+            return true
+        }
+        let userDictionaryFiles = [
+            "user.loudschars2",
+            "user.louds",
+            "user_shortcuts.loudschars2",
+            "user_shortcuts.louds"
+        ]
+        let hasUserDictionaryFile = userDictionaryFiles.contains {
+            FileManager.default.fileExists(
+                atPath: userDictionaryURL.appendingPathComponent($0).path
+            )
+        }
+        self.staticConversionCacheEligibility = !hasUserDictionaryFile
+        return !hasUserDictionaryFile
     }
 
     private func resetMemoryLOUDSCache() {

--- a/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
+++ b/Sources/KanaKanjiConverterModule/InputManagement/ComposingText.swift
@@ -108,11 +108,19 @@ public struct ComposingText: Sendable {
         var convertedLength = 0
 
         for (currentInputIndex, element) in input.enumerated() {
+            let previousElementCount = converting.count
+            let previousTailCount = converting.last?.string.count ?? 0
             // 現在の文字を入力した際に関連(依存)した文字列の長さ
             let deletedCount = Self.updateConvertTargetElements(currentElements: &converting, newElement: element)
 
             let previousConvertedLength = convertedLength
-            convertedLength = converting.reduce(0) { $0 + $1.string.count }
+            let currentTailCount = converting.last?.string.count ?? 0
+            if converting.count == previousElementCount {
+                convertedLength += currentTailCount - previousTailCount
+            } else {
+                // 入力方式が変わり、新しい独立した末尾要素が追加された。
+                convertedLength += currentTailCount
+            }
 
             // 今回の文字入力による変換が、前の暫定独立セグメントの文字を含むローマ字テーブルエントリによって行われた場合
             // 入力は前のセグメントに依存しているので、前のセグメントとの境界を消し、より長い独立セグメントにする
@@ -383,8 +391,25 @@ public struct ComposingText: Sendable {
         // [き, ょ, う, は, い, い, て, ん, き, だ]
         // i2c: [0: 0, 3: 2(きょ), 4: 3(う), 6: 4(は), 7: 5(い), 8: 6(い), 10: 7(て), 13: 9(んき), 15: 10(だ)]
 
+        if self.hasIdentityInputSurfaceIndexMapping {
+            return Dictionary(uniqueKeysWithValues: (0 ... self.input.count).map { ($0, $0) })
+        }
+
         let segmentBoundaries = getIndependentSegmentBoundaries()
         return Dictionary(segmentBoundaries.map { ($0.inputIndex, $0.surfaceIndex) }) { _, second in second }
+    }
+
+    var hasIdentityInputSurfaceIndexMapping: Bool {
+        self.input.count == self.convertTarget.count
+            && self.input.allSatisfy {
+                guard $0.inputStyle == .direct else {
+                    return false
+                }
+                if case .character = $0.piece {
+                    return true
+                }
+                return false
+            }
     }
 
     public mutating func stopComposition() {
@@ -497,7 +522,7 @@ extension ComposingText {
 
 // Equatableにしておく
 extension ComposingText: Equatable {}
-extension ComposingText.InputElement: Equatable {}
+extension ComposingText.InputElement: Hashable {}
 extension ComposingText.ConvertTargetElement: Equatable {
     static func == (lhs: ComposingText.ConvertTargetElement, rhs: ComposingText.ConvertTargetElement) -> Bool {
         lhs.inputStyle == rhs.inputStyle && lhs.string == rhs.string

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -155,4 +155,59 @@ final class ZenzPromptBuilderTests: XCTestCase {
 
         XCTAssertEqual(constraint, Kana2Kanji.PrefixConstraint(Array("橋".utf8), hasEOS: true, ignoreMemoryAndUserDictionary: true))
     }
+
+    func testZenzEvaluationCacheEvictsLeastRecentlyUsedEntry() {
+        let cache = ZenzEvaluationCache(capacity: 2)
+        func key(_ prompt: String) -> ZenzEvaluationCacheKey {
+            ZenzEvaluationCacheKey(
+                prompt: prompt,
+                candidateTextForEvaluation: "候補",
+                originalCandidateText: "候補",
+                prefixConstraint: .init([]),
+                requestRichCandidates: false,
+                reusesAddressedPrefix: false,
+                candidateSegments: [.init(word: "候補", ruby: "コウホ", isLearned: false)]
+            )
+        }
+        let first = key("first")
+        let second = key("second")
+        let third = key("third")
+
+        cache.insert(.wholeResult("first"), for: first)
+        cache.insert(.wholeResult("second"), for: second)
+        XCTAssertEqual(cache.value(for: first), .wholeResult("first"))
+
+        cache.insert(.wholeResult("third"), for: third)
+
+        XCTAssertNil(cache.value(for: second))
+        XCTAssertEqual(cache.value(for: first), .wholeResult("first"))
+        XCTAssertEqual(cache.value(for: third), .wholeResult("third"))
+    }
+
+    func testZenzInferenceThreadCountUsesPerformanceClusterOnDarwin() {
+        XCTAssertEqual(
+            ZenzContext.selectInferenceThreadCount(
+                activeProcessorCount: 10,
+                performanceCoreCount: 6
+            ),
+            6
+        )
+    }
+
+    func testZenzInferenceThreadCountFallsBackWhenPerformanceClusterIsUnavailable() {
+        XCTAssertEqual(
+            ZenzContext.selectInferenceThreadCount(
+                activeProcessorCount: 8,
+                performanceCoreCount: nil
+            ),
+            6
+        )
+        XCTAssertEqual(
+            ZenzContext.selectInferenceThreadCount(
+                activeProcessorCount: 2,
+                performanceCoreCount: nil
+            ),
+            2
+        )
+    }
 }

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -184,6 +184,39 @@ final class ZenzPromptBuilderTests: XCTestCase {
         XCTAssertEqual(cache.value(for: third), .wholeResult("third"))
     }
 
+    func testZenzDraftConversionCacheEvictsLeastRecentlyUsedEntry() {
+        let cache = ZenzDraftConversionCache(capacity: 2)
+        let dictionary = NSObject()
+        func key(_ target: String) -> ZenzDraftConversionCacheKey {
+            ZenzDraftConversionCacheKey(
+                dictionaryIdentifier: ObjectIdentifier(dictionary),
+                input: [],
+                convertTarget: target,
+                convertTargetCursorPosition: nil,
+                keyboardLanguage: .ja_JP,
+                versionDependentConfig: .v3(.init()),
+                prefixConstraint: .init([])
+            )
+        }
+        let value = ZenzDraftConversion(
+            resultPrevs: [],
+            resultLatticeHead: .init(nodes: [])
+        )
+        let first = key("first")
+        let second = key("second")
+        let third = key("third")
+
+        cache.insert(value, for: first)
+        cache.insert(value, for: second)
+        XCTAssertNotNil(cache.value(for: first))
+
+        cache.insert(value, for: third)
+
+        XCTAssertNil(cache.value(for: second))
+        XCTAssertNotNil(cache.value(for: first))
+        XCTAssertNotNil(cache.value(for: third))
+    }
+
     func testZenzInferenceThreadCountUsesPerformanceClusterOnDarwin() {
         XCTAssertEqual(
             ZenzContext.selectInferenceThreadCount(

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -186,10 +186,8 @@ final class ZenzPromptBuilderTests: XCTestCase {
 
     func testZenzDraftConversionCacheEvictsLeastRecentlyUsedEntry() {
         let cache = ZenzDraftConversionCache(capacity: 2)
-        let dictionary = NSObject()
         func key(_ target: String) -> ZenzDraftConversionCacheKey {
             ZenzDraftConversionCacheKey(
-                dictionaryIdentifier: ObjectIdentifier(dictionary),
                 input: [],
                 convertTarget: target,
                 convertTargetCursorPosition: nil,
@@ -215,6 +213,69 @@ final class ZenzPromptBuilderTests: XCTestCase {
         XCTAssertNil(cache.value(for: second))
         XCTAssertNotNil(cache.value(for: first))
         XCTAssertNotNil(cache.value(for: third))
+    }
+
+    func testZenzaiSessionCachesDoNotShareEntries() {
+        let firstSession = ZenzaiSessionCache()
+        let secondSession = ZenzaiSessionCache()
+        let evaluationKey = ZenzEvaluationCacheKey(
+            prompt: "prompt",
+            candidateTextForEvaluation: "候補",
+            originalCandidateText: "候補",
+            prefixConstraint: .init([]),
+            requestRichCandidates: false,
+            reusesAddressedPrefix: false,
+            candidateSegments: [.init(word: "候補", ruby: "コウホ", isLearned: false)]
+        )
+        let draftKey = ZenzDraftConversionCacheKey(
+            input: [],
+            convertTarget: "こうほ",
+            convertTargetCursorPosition: nil,
+            keyboardLanguage: .ja_JP,
+            versionDependentConfig: .v3(.init()),
+            prefixConstraint: .init([])
+        )
+        let resolvedKey = ZenzResolvedConversionCacheKey(
+            input: [],
+            convertTarget: "こうほ",
+            convertTargetCursorPosition: nil,
+            keyboardLanguage: .ja_JP,
+            versionDependentConfig: .v3(.init()),
+            prefixConstraint: .init([]),
+            inferenceLimit: 1
+        )
+        let latticeHead = ZenzResolvedLatticeHead(nodes: [])
+        let draft = ZenzDraftConversion(resultPrevs: [], resultLatticeHead: latticeHead)
+        let candidate = Candidate(
+            text: "候補",
+            value: 0,
+            composingCount: .inputCount(0),
+            lastMid: 0,
+            data: []
+        )
+        let resolved = ZenzResolvedConversion(
+            resultPrevs: [],
+            resultLatticeHead: latticeHead,
+            prefixConstraint: .init([]),
+            satisfyingCandidate: candidate
+        )
+
+        firstSession.cacheEvaluation(.wholeResult("cached"), for: evaluationKey)
+        firstSession.cacheDraftConversion(draft, for: draftKey)
+        firstSession.cacheResolvedConversion(resolved, for: resolvedKey)
+        firstSession.cacheEvaluationPromptTokens([1, 2, 3], for: "prompt")
+
+        XCTAssertEqual(
+            firstSession.cachedEvaluation(for: evaluationKey),
+            .wholeResult("cached")
+        )
+        XCTAssertNotNil(firstSession.cachedDraftConversion(for: draftKey))
+        XCTAssertNotNil(firstSession.cachedResolvedConversion(for: resolvedKey))
+        XCTAssertEqual(firstSession.cachedEvaluationPromptTokens(for: "prompt"), [1, 2, 3])
+        XCTAssertNil(secondSession.cachedEvaluation(for: evaluationKey))
+        XCTAssertNil(secondSession.cachedDraftConversion(for: draftKey))
+        XCTAssertNil(secondSession.cachedResolvedConversion(for: resolvedKey))
+        XCTAssertNil(secondSession.cachedEvaluationPromptTokens(for: "prompt"))
     }
 
     func testZenzInferenceThreadCountUsesPerformanceClusterOnDarwin() {

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -36,6 +36,10 @@ final class ZenzaiTests: XCTestCase {
         )
     }
 
+    private func inferenceLimitLabel(_ inferenceLimit: Int) -> String {
+        inferenceLimit == .max ? "max" : String(inferenceLimit)
+    }
+
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: KanaKanjiConverterModule.InputStyle) {
         for char in sequence {
             composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
@@ -139,6 +143,8 @@ final class ZenzaiTests: XCTestCase {
     }
 
     func testFullConversion() async throws {
+        // 各doブロックは独立した変換セッションである。同じ入力を繰り返すケースも、
+        // 以前のConverterの変換結果キャッシュに依存せず再評価される必要がある。
         do {
             let converter = KanaKanjiConverter.withDefaultDictionary()
             var c = ComposingText()
@@ -180,11 +186,12 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
-        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
-        defer {
-            self.reportLatencies(latencies, label: "Direct")
-        }
+        let profilesLatency = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1"
+        // inferenceLimitごとに独立したシナリオとして測る。Converterは必ずループ内で
+        // 生成し、別limitで得た変換結果LRUのwarm hitを性能値へ混入させないこと。
+        // モデル重みとnative contextの共有は、製品のメモリ設計どおり許容する。
         for inferenceLimit in [1, 2, 3, 5, .max] {
+            var latencies: [Double]? = profilesLatency ? [] : nil
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "このぶんしょうはかんじへんかんがせいかくということでわだいのにほんごにゅうりょくしすてむをつかってうちこんでいます"
@@ -200,6 +207,10 @@ final class ZenzaiTests: XCTestCase {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
             }
+            self.reportLatencies(
+                latencies,
+                label: "Direct inferenceLimit=\(self.inferenceLimitLabel(inferenceLimit))"
+            )
         }
     }
 
@@ -207,11 +218,12 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion_Roman2Kana() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
-        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
-        defer {
-            self.reportLatencies(latencies, label: "Roman2Kana")
-        }
+        let profilesLatency = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1"
+        // inferenceLimitごとに独立したシナリオとして測る。Converterは必ずループ内で
+        // 生成し、別limitで得た変換結果LRUのwarm hitを性能値へ混入させないこと。
+        // モデル重みとnative contextの共有は、製品のメモリ設計どおり許容する。
         for inferenceLimit in [1, 2, 3, 5, .max] {
+            var latencies: [Double]? = profilesLatency ? [] : nil
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "konobunshouhakanjihenkangaseikakutoiukotodewadainonihongonyuuryokusisutemuwotukatteutikondeimasu"
@@ -227,6 +239,10 @@ final class ZenzaiTests: XCTestCase {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
             }
+            self.reportLatencies(
+                latencies,
+                label: "Roman2Kana inferenceLimit=\(self.inferenceLimitLabel(inferenceLimit))"
+            )
         }
     }
 
@@ -234,11 +250,12 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion_AZIK() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
-        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
-        defer {
-            self.reportLatencies(latencies, label: "AZIK")
-        }
+        let profilesLatency = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1"
+        // inferenceLimitごとに独立したシナリオとして測る。Converterは必ずループ内で
+        // 生成し、別limitで得た変換結果LRUのwarm hitを性能値へ混入させないこと。
+        // モデル重みとnative contextの共有は、製品のメモリ設計どおり許容する。
         for inferenceLimit in [1, 2, 3, 5, .max] {
+            var latencies: [Double]? = profilesLatency ? [] : nil
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "konobjxphakzzihdkzgasskakutoiuktdewadqnonihlgonyhryokusisutemuwotuka；teutikldwms"
@@ -254,6 +271,10 @@ final class ZenzaiTests: XCTestCase {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
             }
+            self.reportLatencies(
+                latencies,
+                label: "AZIK inferenceLimit=\(self.inferenceLimitLabel(inferenceLimit))"
+            )
         }
     }
 

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -4,6 +4,37 @@ import XCTest
 
 #if Zenzai || ZenzaiCPU
 final class ZenzaiTests: XCTestCase {
+    private func measuredRequestCandidates(
+        _ converter: KanaKanjiConverter,
+        composingText: ComposingText,
+        options: ConvertRequestOptions,
+        latencies: inout [Double]?
+    ) -> ConversionResult {
+        guard latencies != nil else {
+            return converter.requestCandidates(composingText, options: options)
+        }
+        let start = ProcessInfo.processInfo.systemUptime
+        let result = converter.requestCandidates(composingText, options: options)
+        latencies?.append((ProcessInfo.processInfo.systemUptime - start) * 1_000)
+        return result
+    }
+
+    private func reportLatencies(_ latencies: [Double]?, label: String) {
+        guard let latencies, !latencies.isEmpty else {
+            return
+        }
+        let sorted = latencies.sorted()
+        let average = sorted.reduce(0, +) / Double(sorted.count)
+        let p90Index = min(sorted.count - 1, Int(ceil(Double(sorted.count) * 0.9)) - 1)
+        print(
+            "[ZenzaiLatency] \(label)"
+                + " count=\(sorted.count)"
+                + " averageMs=\(average)"
+                + " p90Ms=\(sorted[p90Index])"
+                + " maxMs=\(sorted[sorted.count - 1])"
+        )
+    }
+
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: KanaKanjiConverterModule.InputStyle) {
         for char in sequence {
             composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
@@ -14,7 +45,6 @@ final class ZenzaiTests: XCTestCase {
         inferenceLimit: Int = Int.max,
         leftSideContext: String? = nil
     ) -> ConvertRequestOptions {
-        print("You need to install azooKeyMac.app to run this test.")
         return .init(
             N_best: 10,
             requireJapanesePrediction: .disabled,
@@ -83,13 +113,22 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
+        defer {
+            self.reportLatencies(latencies, label: "Direct")
+        }
         for inferenceLimit in [1, 2, 3, 5, .max] {
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "このぶんしょうはかんじへんかんがせいかくということでわだいのにほんごにゅうりょくしすてむをつかってうちこんでいます"
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .direct)
-                let results = converter.requestCandidates(c, options: requestOptions(inferenceLimit: inferenceLimit))
+                let results = self.measuredRequestCandidates(
+                    converter,
+                    composingText: c,
+                    options: requestOptions(inferenceLimit: inferenceLimit),
+                    latencies: &latencies
+                )
                 if c.input.count == text.count {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
@@ -101,13 +140,22 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion_Roman2Kana() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
+        defer {
+            self.reportLatencies(latencies, label: "Roman2Kana")
+        }
         for inferenceLimit in [1, 2, 3, 5, .max] {
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "konobunshouhakanjihenkangaseikakutoiukotodewadainonihongonyuuryokusisutemuwotukatteutikondeimasu"
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .roman2kana)
-                let results = converter.requestCandidates(c, options: requestOptions(inferenceLimit: inferenceLimit))
+                let results = self.measuredRequestCandidates(
+                    converter,
+                    composingText: c,
+                    options: requestOptions(inferenceLimit: inferenceLimit),
+                    latencies: &latencies
+                )
                 if c.input.count == text.count {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }
@@ -119,13 +167,22 @@ final class ZenzaiTests: XCTestCase {
     func testGradualConversion_AZIK() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        var latencies: [Double]? = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1" ? [] : nil
+        defer {
+            self.reportLatencies(latencies, label: "AZIK")
+        }
         for inferenceLimit in [1, 2, 3, 5, .max] {
             let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
             var c = ComposingText()
             let text = "konobjxphakzzihdkzgasskakutoiuktdewadqnonihlgonyhryokusisutemuwotuka；teutikldwms"
             for char in text {
                 c.insertAtCursorPosition(String(char), inputStyle: .mapped(id: .defaultAZIK))
-                let results = converter.requestCandidates(c, options: requestOptions(inferenceLimit: inferenceLimit))
+                let results = self.measuredRequestCandidates(
+                    converter,
+                    composingText: c,
+                    options: requestOptions(inferenceLimit: inferenceLimit),
+                    latencies: &latencies
+                )
                 if c.input.count == text.count {
                     XCTAssertEqual(results.mainResults.first?.text, "この文章は漢字変換が正確ということで話題の日本語入力システムを使って打ち込んでいます")
                 }

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import KanaKanjiConverterModule
 @testable import KanaKanjiConverterModuleWithDefaultDictionary
 import XCTest
 
@@ -69,6 +70,72 @@ final class ZenzaiTests: XCTestCase {
             typoCorrectionMode: .automatic,
             metadata: nil
         )
+    }
+
+    func testIncrementalLatticeMatchesFullRebuildForRomanAndAZIKTailRewrites() {
+        let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        let kanaKanji = Kana2Kanji(dicdataStore: dicdataStore)
+        let state = dicdataStore.prepareState()
+
+        func firstTailRewrite(
+            in sequence: String,
+            inputStyle: InputStyle
+        ) -> (old: ComposingText, new: ComposingText)? {
+            var current = ComposingText()
+            for character in sequence {
+                let old = current
+                current.insertAtCursorPosition(String(character), inputStyle: inputStyle)
+                if !old.convertTarget.isEmpty,
+                   !current.convertTarget.hasPrefix(old.convertTarget) {
+                    return (old, current)
+                }
+            }
+            return nil
+        }
+
+        func assertIncrementalMatchesFull(
+            _ pair: (old: ComposingText, new: ComposingText),
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let oldResult = kanaKanji.kana2lattice_all(
+                pair.old,
+                N_best: 2,
+                needTypoCorrection: false,
+                dicdataStoreState: state
+            )
+            let incrementalLattice = kanaKanji.buildLatticeWithIncrementalCache(
+                inputData: pair.new,
+                inputCount: pair.new.input.count,
+                surfaceCount: pair.new.convertTarget.count,
+                incrementalCacheInfo: (pair.old, oldResult.lattice),
+                dicdataStoreState: state
+            )
+            let incremental = kanaKanji.kana2lattice_all(
+                pair.new,
+                N_best: 2,
+                needTypoCorrection: false,
+                preprocessedLattice: incrementalLattice,
+                dicdataStoreState: state
+            )
+            let full = kanaKanji.kana2lattice_all(
+                pair.new,
+                N_best: 2,
+                needTypoCorrection: false,
+                dicdataStoreState: state
+            )
+            let incrementalCandidates = incremental.result.getCandidateData().map(kanaKanji.processClauseCandidate)
+            let fullCandidates = full.result.getCandidateData().map(kanaKanji.processClauseCandidate)
+            XCTAssertEqual(incrementalCandidates.map(\.text), fullCandidates.map(\.text), file: file, line: line)
+            XCTAssertEqual(incrementalCandidates.map(\.value), fullCandidates.map(\.value), file: file, line: line)
+        }
+
+        let roman = firstTailRewrite(in: "konobunshou", inputStyle: .roman2kana)
+        let azik = firstTailRewrite(in: "konobjxp", inputStyle: .mapped(id: .defaultAZIK))
+        XCTAssertNotNil(roman)
+        XCTAssertNotNil(azik)
+        if let roman { assertIncrementalMatchesFull(roman) }
+        if let azik { assertIncrementalMatchesFull(azik) }
     }
 
     func testFullConversion() async throws {


### PR DESCRIPTION
## 概要

ZenzaiのCPU/GPU推論、incremental変換、メモリ使用量をまとめて最適化し、結果キャッシュをモデル共有状態から変換セッションへ移します。

このPRは #346、#348、#349 の変更を `main` に対する1本の差分としてまとめ直したものです。旧PRは履歴・議論を残すため、このPR作成時点ではcloseしていません。

## 主な変更

- Zenzai CPU推論をllama.cpp b9637ベースへ更新し、CPUトポロジに応じたスレッド数、CPU-only backend、KV prefix再利用、batch/microbatch調整、Flash Attentionを適用
- 評価時の不要なdecode・softmax・token処理を削減
- Roman2Kana/AZIKのincremental入力で、確定済み変換境界までのlattice結果を再利用
- `RegisteredNode` のN-best payload共有、LOUDS indexの`UInt32`化、SpellCheckerの一時割り当て削減
- iOS CPU推論ではweight repack用の追加bufferを無効化し、メモリ使用量を削減（iOS 17以降を対象）
- Direct stable-prefix projectionは、意味保存を厳密に保証しにくいため削除

## セッションキャッシュのリファクタ

これまでは結果キャッシュが共有モデルに属していたため、別converter・別テスト・異なる`inferenceLimit`の間でも結果が残り、benchmarkの繰り返しがwarm hitになり得ました。

このPRでは以下を`ConversionSessionState`所有の`ZenzaiSessionCache`へ移しています。

- 評価結果LRU: 256件
- 解決済み変換LRU: 64件
- draft変換LRU: 128件
- prompt token LRU: 128件

`stopComposition()`、scratch session、モデルURL変更時には新しいセッションキャッシュを使います。解決済み変換のキーには`inferenceLimit`とprefix constraintも含めます。一方、モデルweight・native llama context・厳密なtoken prefix照合を行うKV cacheは、意図したプロダクト設計として共有を維持します。

benchmarkは各`inferenceLimit`を独立した利用セッションとして計測する意図をコメントに明記し、limitごとにconverterを再生成して個別にレポートするよう変更しました。

## 性能

M2 Pro / release / 実モデル / `main`との比較。各ケース5回のsteady run平均です。旧`main`の初回だけMetal shader初期化が入ったため、そのcold-start値は平均から除外しています。

| ケース | main CPU | このPR CPU | 改善 |
|---|---:|---:|---:|
| Full | 0.679秒 | 0.349秒 | 1.95倍 / -48.7% |
| Direct incremental | 8.850秒 | 3.736秒 | 2.37倍 / -57.8% |
| Roman2Kana incremental | 15.962秒 | 5.007秒 | 3.19倍 / -68.6% |
| AZIK incremental | 13.398秒 | 3.368秒 | 3.98倍 / -74.9% |

| ケース | main GPU | このPR GPU | 改善 |
|---|---:|---:|---:|
| Full | 0.535秒 | 0.372秒 | 1.44倍 / -30.5% |
| Direct incremental | 4.591秒 | 3.326秒 | 1.38倍 / -27.6% |
| Roman2Kana incremental | 8.602秒 | 4.458秒 | 1.93倍 / -48.2% |
| AZIK incremental | 7.050秒 | 2.957秒 | 2.38倍 / -58.1% |

## メモリ

- N-best payload共有: peak footprint 57.32 MiB → 53.32 MiB（約-3.82 MiB / -7.0%、実行時間は実質同等）
- LOUDS `UInt32`化: 長文Direct incrementalケースで約-1.65 MiB、約4%高速化
- llama.cpp compute buffer調整: 約-12.7 MiB
- モデルmappingの重複保持を回避
- iOS CPUでweight repackを無効化: 約64 MiB回収（速度とのトレードオフあり）

## 安全性と挙動変更

意味保存を意図する変更は、セッション境界と完全なcache keyによる結果再利用、immutable payload共有、4 GiB未満を確認するLOUDS `UInt32`化、softmaxを省いたlogit比較、batch再利用、確定したRoman/AZIK境界までのlattice再利用です。

一方、以下は性能とのトレードオフを含むヒューリスティック／挙動変更です。

- rich candidateを要求しない制約付き評価ではN-bestを3件から1件へ削減するため、学習辞書・ユーザ辞書・retryを含む一部ケースで候補選択が変わる可能性がある
- Roman/AZIKの未確定suffixがある間はZenz評価を遅延するため、入力途中の候補更新タイミングが変わる
- CPUスレッド数は実機トポロジから選ぶヒューリスティックであり、実測autotuningではない
- iOS CPUのweight repack無効化はメモリ優先で、端末によっては速度低下の可能性がある

## 検証

- `ZenzPromptBuilderTests`: 16件成功
- ZenzaiCPUの`ZenzaiTests`: 6件成功
- arm64 iOS 17 Simulator向けrelease build成功
- CPU/GPUの4 benchmarkケースを`main`と比較
- 異なる`ZenzaiSessionCache`間で評価・draft・解決済み変換・prompt tokenの各entryが共有されないunit testを追加

### GPUテストの既知事項

各GPUテスト本体は成功しますが、テスト終了後のMetal teardownでllama.cpp b9637の`GGML_ASSERT([rsets->data count] == 0)`が発生し、processがsignal 6で終了します。今回のセッションキャッシュ変更を含まない #349 のclean branchでも単独テストで再現するため、このリファクタ由来ではありません。ただし、GPU test suite全体がgreenという状態ではありません。

