### PR TITLE
fix(zenzai): iOSのDirect入力性能とキャッシュ寿命を復旧する

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,8 +144,8 @@ let llamaCppTarget: Target = .systemLibrary(name: "llama.cpp")
 #else
 let llamaCppTarget: Target = .binaryTarget(
     name: "llama.cpp",
-    url: "https://github.com/azooKey/llama.cpp/releases/download/b9637-azookey.1/signed-llama-b9637-azookey.1.xcframework.zip",
-    checksum: "6176b3a6f7cbeca993644ca21d4b1c46ddaa59b98109376b7d32acef8e226a13"
+    url: "https://github.com/azooKey/llama.cpp/releases/download/b4846/signed-llama.xcframework.zip",
+    checksum: "db3b13169df8870375f212e6ac21194225f1c85f7911d595ab64c8c790068e0a"
 )
 #endif
 targets.append(llamaCppTarget)

--- a/Package.swift
+++ b/Package.swift
@@ -142,6 +142,17 @@ if checkObjcAvailability() {
 #if os(Windows) || os(Linux)
 let llamaCppTarget: Target = .systemLibrary(name: "llama.cpp")
 #else
+// b4846 is intentionally pinned instead of b9637-azookey.1.
+// On iOS devices, Direct input was fast at 0e67a1f (b4846), regressed at the
+// immediately following db4632f (b9637), and recovered after restoring b4846.
+// b9637's Apple Silicon CPU speedup depends on runtime weight repacking: on an
+// M2 Pro it reduced steady-state latency from about 10.8 to 7.2 ms/request, but
+// allocated a 63.77 MiB anonymous CPU_REPACK buffer in addition to the GGUF mmap.
+// Disabling repacking removed that speedup (about 10.6 ms/request), while the
+// iOS regression remained. The macOS product uses the GPU path, where b4846 did
+// not regress; b9637 also hit a Metal residency-set assertion during shutdown.
+// Reconsider this pin only after both the iOS small-batch regression and the
+// repack memory/lifecycle costs have been addressed and measured on device.
 let llamaCppTarget: Target = .binaryTarget(
     name: "llama.cpp",
     url: "https://github.com/azooKey/llama.cpp/releases/download/b4846/signed-llama.xcframework.zip",

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/Zenz.swift
@@ -72,7 +72,7 @@ package final class Zenz {
         prefixConstraint: Kana2Kanji.PrefixConstraint,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
-        sessionCache: ZenzaiSessionCache
+        memoizationCache: ZenzaiMemoizationCache
     ) -> CandidateEvaluationResult {
         self.inferenceLock.withLock {
             guard let zenzContext else {
@@ -88,7 +88,7 @@ package final class Zenz {
                     prefixConstraint: prefixConstraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig,
-                    sessionCache: sessionCache
+                    memoizationCache: memoizationCache
                 )
             }
             return .error

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -87,7 +87,7 @@ struct ZenzCandidateEvaluator {
         prefixConstraint: Kana2Kanji.PrefixConstraint,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
-        sessionCache: ZenzaiSessionCache
+        memoizationCache: ZenzaiMemoizationCache
     ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
         var userDictionaryPrompt = ""
@@ -133,17 +133,20 @@ struct ZenzCandidateEvaluator {
         } else {
             nil
         }
-        if let cacheKey, let cached = sessionCache.cachedEvaluation(for: cacheKey) {
+        if let cacheKey, let cached = memoizationCache.cachedEvaluation(for: cacheKey) {
             return cached
         }
         func finish(_ result: CandidateEvaluationResult) -> CandidateEvaluationResult {
             if let cacheKey, result != .error {
-                sessionCache.cacheEvaluation(result, for: cacheKey)
+                memoizationCache.cacheEvaluation(result, for: cacheKey)
             }
             return result
         }
 
-        let promptTokens = context.encodeEvaluationPrompt(prompt, sessionCache: sessionCache)
+        let promptTokens = context.encodeEvaluationPrompt(
+            prompt,
+            memoizationCache: memoizationCache
+        )
         let candidateTokens = context.encode(candidateTextForEvaluation, addBOS: false, addEOS: false)
         let addressedTokens: [llama_token]
         if reusesAddressedPrefix {

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -30,11 +30,6 @@ enum ZenzError: LocalizedError {
 /// コンテキストより先に解放される可能性があるプロセス終了時の明示解放は行わない。
 private enum ZenzBackend {
     private static let initialized: Void = {
-        #if ZenzaiCPU && canImport(Darwin)
-        // llama.cpp b9637ではbackend registry生成時にMetalも初期化される。
-        // CPU推論ではMetal shaderの初期ロードを避ける。
-        setenv("GGML_DISABLE_METAL", "1", 0)
-        #endif
         llama_backend_init()
     }()
 
@@ -279,11 +274,6 @@ private final class SharedZenzModel {
         ZenzBackend.initializeIfNeeded()
         var modelParams = llama_model_default_params()
         modelParams.use_mmap = true
-        #if ZenzaiCPU && os(iOS)
-        // b9637のCPU weight repackはモデルと同程度の追加bufferを常駐させる。
-        // iOSのメモリ制約を優先し、mmapされた元の量子化weightを直接利用する。
-        modelParams.use_extra_bufts = false
-        #endif
         #if ZenzaiCPU
         modelParams.n_gpu_layers = 0
         modelParams.split_mode = LLAMA_SPLIT_MODE_NONE
@@ -376,16 +366,7 @@ final class ZenzContext {
         debug("Using \(n_threads) threads")
         var ctx_params = llama_context_default_params()
         ctx_params.n_ctx = 512
-        #if os(Linux) || os(Windows)
         ctx_params.flash_attn = true
-        #else
-        // 評価用(0)と入力予測用(1)の2 sequenceを同一KV cacheで扱う。
-        ctx_params.n_seq_max = 2
-        // 両sequenceはpromptの大部分を共有する。512 tokenの総容量を分割せず、
-        // 従来と同じ容量のKV cacheとして共有する。
-        ctx_params.kv_unified = true
-        ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED
-        #endif
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
         ctx_params.n_batch = 512
@@ -482,9 +463,6 @@ final class ZenzContext {
     }
 
     private func getLogits(tokens: [llama_token], logits_start_index: Int = 0, seqId: llama_seq_id = 0) -> UnsafeMutablePointer<Float>? {
-        #if !os(Linux) && !os(Windows)
-        let memory = llama_get_memory(self.context)
-        #endif
         let currentPrevInput = self.prevInputBySeq[seqId] ?? []
         var effectivePrevInput = currentPrevInput
 
@@ -502,13 +480,8 @@ final class ZenzContext {
             if otherPrefix > currentPrefix {
                 let copiedPrefixCount = min(otherPrefix, logits_start_index)
                 if copiedPrefixCount > 0 {
-                    #if os(Linux) || os(Windows)
                     llama_kv_cache_seq_rm(context, seqId, 0, -1)
                     llama_kv_cache_seq_cp(context, otherSeqId, seqId, 0, llama_pos(copiedPrefixCount))
-                    #else
-                    llama_memory_seq_rm(memory, seqId, 0, -1)
-                    llama_memory_seq_cp(memory, otherSeqId, seqId, 0, llama_pos(copiedPrefixCount))
-                    #endif
                     effectivePrevInput = otherPrevInput
                 }
             }
@@ -517,23 +490,14 @@ final class ZenzContext {
         // Manage KV cache: remove entries that differ from previous input
         let prefixCacheCount: Int
         do {
-            #if os(Linux) || os(Windows)
             let pos_max = llama_kv_cache_seq_pos_max(self.context, seqId)
-            #else
-            let pos_max = llama_memory_seq_pos_max(memory, seqId)
-            #endif
             debug("pos max:", pos_max, "prevInput count:", effectivePrevInput.count, "tokens count:", tokens.count)
             let commonTokens = effectivePrevInput.commonPrefix(with: tokens)
             // Remove KV cache from position commonTokens.count onwards to recompute divergent part
             // removed range: [llama_pos(commonTokens.count), inf)
             prefixCacheCount = min(commonTokens.count, logits_start_index)
-            #if os(Linux) || os(Windows)
             llama_kv_cache_seq_rm(context, seqId, llama_pos(prefixCacheCount), -1)
             debug("new pos max:", llama_kv_cache_seq_pos_max(self.context, seqId), "commonTokens:", commonTokens.count)
-            #else
-            llama_memory_seq_rm(memory, seqId, llama_pos(prefixCacheCount), -1)
-            debug("new pos max:", llama_memory_seq_pos_max(memory, seqId), "commonTokens:", commonTokens.count)
-            #endif
         }
         self.batch.n_tokens = 0
         let n_ctx = llama_n_ctx(context)

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzContext.swift
@@ -199,12 +199,12 @@ final class ZenzDraftConversionCache: @unchecked Sendable {
     private let lock = NSLock()
 }
 
-/// 1つの変換セッション内だけで再利用するZenzaiのメモ化キャッシュ。
+/// 1つの`KanaKanjiConverter`内で再利用するZenzaiのメモ化キャッシュ。
 ///
-/// モデルやnative contextとは所有者を分け、Converterのセッション終了時に確実に
-/// 破棄されるようにする。これにより、別セッションや別テストの同一入力が以前の
-/// 変換結果を引き継がない。
-final class ZenzaiSessionCache: @unchecked Sendable {
+/// モデルやnative contextとは所有者を分け、別Converter間では共有しない。一方、
+/// `stopComposition()`は入力中の状態だけを終了するAPIなので、このキャッシュは
+/// compositionを跨いで保持する。
+final class ZenzaiMemoizationCache: @unchecked Sendable {
     init(
         evaluationCapacity: Int = 256,
         resolvedConversionCapacity: Int = 64,
@@ -568,13 +568,13 @@ final class ZenzContext {
 
     func encodeEvaluationPrompt(
         _ prompt: String,
-        sessionCache: ZenzaiSessionCache
+        memoizationCache: ZenzaiMemoizationCache
     ) -> [llama_token] {
-        if let cached = sessionCache.cachedEvaluationPromptTokens(for: prompt) {
+        if let cached = memoizationCache.cachedEvaluationPromptTokens(for: prompt) {
             return cached
         }
         let tokens = self.encode(prompt, addBOS: true, addEOS: false)
-        sessionCache.cacheEvaluationPromptTokens(tokens, for: prompt)
+        memoizationCache.cacheEvaluationPromptTokens(tokens, for: prompt)
         return tokens
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/llama-mock.swift
@@ -11,13 +11,10 @@ package typealias llama_seq_id = Int32
 package struct llama_context_params {
     package var seed: Int
     package var n_ctx: Int
-    package var n_seq_max: Int
-    package var kv_unified: Bool
     package var n_threads: Int32
     package var n_threads_batch: Int32
     package var n_batch: Int
     package var flash_attn: Bool
-    package var flash_attn_type: Int32
     package var no_perf: Bool
 }
 package func llama_context_default_params() -> llama_context_params { unimplemented() }
@@ -36,7 +33,6 @@ package func llama_backend_free() {}
 
 package struct llama_model_params {
     package var use_mmap: Bool
-    package var use_extra_bufts: Bool
 }
 package func llama_model_default_params() -> llama_model_params { unimplemented() }
 
@@ -47,13 +43,6 @@ package func llama_model_load_from_file(_: String, _: llama_model_params) -> lla
 package func llama_kv_cache_seq_rm(_: llama_context, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
 package func llama_kv_cache_seq_cp(_: llama_context, _: llama_seq_id, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
 package func llama_kv_cache_seq_pos_max(_: llama_context, _: llama_seq_id) -> Int { unimplemented() }
-
-package let LLAMA_FLASH_ATTN_TYPE_ENABLED: Int32 = 1
-package typealias llama_memory = OpaquePointer
-package func llama_get_memory(_: llama_context) -> llama_memory { unimplemented() }
-package func llama_memory_seq_rm(_: llama_memory, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
-package func llama_memory_seq_cp(_: llama_memory, _: llama_seq_id, _: llama_seq_id, _: llama_pos, _: llama_pos) {}
-package func llama_memory_seq_pos_max(_: llama_memory, _: llama_seq_id) -> Int { unimplemented() }
 
 package struct llama_batch {
     package var token: [llama_token]

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -114,7 +114,7 @@ extension Kana2Kanji {
         _ inputData: ComposingText,
         zenz: Zenz,
         zenzaiCache: ZenzaiCache?,
-        zenzaiSessionCache: ZenzaiSessionCache,
+        zenzaiMemoizationCache: ZenzaiMemoizationCache,
         inferenceLimit: Int,
         requestRichCandidates: Bool,
         personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
@@ -148,7 +148,7 @@ extension Kana2Kanji {
                 nil
         }
         if let resolvedConversionCacheKey,
-           let cached = zenzaiSessionCache.cachedResolvedConversion(
+           let cached = zenzaiMemoizationCache.cachedResolvedConversion(
                for: resolvedConversionCacheKey
            ) {
             // 全文経路とは別にprocessResultが参照する先頭辞書ノードだけを復元する。
@@ -221,7 +221,7 @@ extension Kana2Kanji {
                 nil
             }
             let cachedDraft = draftCacheKey.flatMap {
-                zenzaiSessionCache.cachedDraftConversion(for: $0)
+                zenzaiMemoizationCache.cachedDraftConversion(for: $0)
             }
             let preprocessedLattice: Lattice?
             if cachedDraft != nil {
@@ -276,7 +276,7 @@ extension Kana2Kanji {
                 )
             }
             if let draftCacheKey, cachedDraft == nil {
-                zenzaiSessionCache.cacheDraftConversion(
+                zenzaiMemoizationCache.cacheDraftConversion(
                     ZenzDraftConversion(
                         resultPrevs: draftResult.result.prevs,
                         resultLatticeHead: ZenzResolvedLatticeHead(
@@ -340,7 +340,7 @@ extension Kana2Kanji {
                     prefixConstraint: constraint,
                     personalizationMode: personalizationMode,
                     versionDependentConfig: versionDependentConfig,
-                    sessionCache: zenzaiSessionCache
+                    memoizationCache: zenzaiMemoizationCache
                 )
                 inferenceLimit -= 1
                 let nextAction = self.review(
@@ -401,7 +401,7 @@ extension Kana2Kanji {
                                    )
                                }
                            }) {
-                            zenzaiSessionCache.cacheResolvedConversion(
+                            zenzaiMemoizationCache.cacheResolvedConversion(
                                 ZenzResolvedConversion(
                                     resultPrevs: insertedCandidates.map(\.0),
                                     resultLatticeHead: ZenzResolvedLatticeHead(

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -19,7 +19,6 @@ public final class KanaKanjiConverter {
         var lattice: Lattice = .init()
         var completedData: Candidate?
         var zenzaiCache: Kana2Kanji.ZenzaiCache?
-        var zenzaiSessionCache: ZenzaiSessionCache = .init()
         var zenzaiTypoCache: ZenzaiTypoGenerationCache = .init()
         var ngramCache: NGramCache = .init()
         var predictiveInputCache: PredictiveInputCacheEntry?
@@ -57,6 +56,9 @@ public final class KanaKanjiConverter {
     private var lastData: DicdataElement?
     /// Zenzaiのためのzenzモデル
     private var zenz: Zenz?
+    /// 完全な入力・文脈・制約をキーにする純粋なメモ化結果。
+    /// compositionではなく、このConverterインスタンスの寿命に紐づける。
+    var zenzaiMemoizationCache = ZenzaiMemoizationCache()
     private var zenzaiPersonalization: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?
     public private(set) var zenzStatus: String = ""
     private var dicdataStoreState: DicdataStoreState
@@ -73,9 +75,7 @@ public final class KanaKanjiConverter {
 
     private func withScratchSession<T>(_ body: () -> T) -> T {
         let scratchID: SessionID = "scratch-\(UUID().uuidString)"
-        var scratchState = self.currentSessionState
-        scratchState.zenzaiSessionCache = .init()
-        self.sessions[scratchID] = scratchState
+        self.sessions[scratchID] = self.currentSessionState
         let previousSessionID = self.activeSessionID
         let savedPersonalization = self.zenzaiPersonalization
         self.activeSessionID = scratchID
@@ -94,6 +94,14 @@ public final class KanaKanjiConverter {
         self.sessions = [Self.defaultSessionID: .init()]
         self.activeSessionID = Self.defaultSessionID
         self.lastData = nil
+    }
+
+    /// Zenzaiの純粋なメモ化結果を明示的に破棄します。
+    ///
+    /// 通常の変換確定では呼ぶ必要はありません。メモリ警告を受けた場合など、
+    /// compositionを終了せずに再計算可能なキャッシュだけを解放したい場合に利用します。
+    public func purgeZenzaiMemoizationCache() {
+        self.zenzaiMemoizationCache = .init()
     }
 
     private func getZenzaiPersonalization(mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode?) -> (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)? {
@@ -207,10 +215,10 @@ public final class KanaKanjiConverter {
         } else {
             do {
                 self.zenz = try Zenz.shared(resourceURL: modelURL)
+                self.purgeZenzaiMemoizationCache()
                 self.sessions = self.sessions.mapValues { state in
-                    var next = state
+                    let next = state
                     next.zenzaiTypoCache.invalidateForModelChange()
-                    next.zenzaiSessionCache = .init()
                     return next
                 }
                 self.zenzStatus = "load \(modelURL.absoluteString)"
@@ -1034,7 +1042,7 @@ public final class KanaKanjiConverter {
                 inputData,
                 zenz: model,
                 zenzaiCache: self.currentSessionState.zenzaiCache,
-                zenzaiSessionCache: self.currentSessionState.zenzaiSessionCache,
+                zenzaiMemoizationCache: self.zenzaiMemoizationCache,
                 inferenceLimit: zenzaiMode.inferenceLimit,
                 requestRichCandidates: zenzaiMode.requestRichCandidates,
                 personalizationMode: self.getZenzaiPersonalization(mode: zenzaiMode.personalizationMode),

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -215,9 +215,9 @@ final class ZenzPromptBuilderTests: XCTestCase {
         XCTAssertNotNil(cache.value(for: third))
     }
 
-    func testZenzaiSessionCachesDoNotShareEntries() {
-        let firstSession = ZenzaiSessionCache()
-        let secondSession = ZenzaiSessionCache()
+    func testZenzaiMemoizationCachesDoNotShareEntries() {
+        let firstCache = ZenzaiMemoizationCache()
+        let secondCache = ZenzaiMemoizationCache()
         let evaluationKey = ZenzEvaluationCacheKey(
             prompt: "prompt",
             candidateTextForEvaluation: "候補",
@@ -260,22 +260,43 @@ final class ZenzPromptBuilderTests: XCTestCase {
             satisfyingCandidate: candidate
         )
 
-        firstSession.cacheEvaluation(.wholeResult("cached"), for: evaluationKey)
-        firstSession.cacheDraftConversion(draft, for: draftKey)
-        firstSession.cacheResolvedConversion(resolved, for: resolvedKey)
-        firstSession.cacheEvaluationPromptTokens([1, 2, 3], for: "prompt")
+        firstCache.cacheEvaluation(.wholeResult("cached"), for: evaluationKey)
+        firstCache.cacheDraftConversion(draft, for: draftKey)
+        firstCache.cacheResolvedConversion(resolved, for: resolvedKey)
+        firstCache.cacheEvaluationPromptTokens([1, 2, 3], for: "prompt")
 
         XCTAssertEqual(
-            firstSession.cachedEvaluation(for: evaluationKey),
+            firstCache.cachedEvaluation(for: evaluationKey),
             .wholeResult("cached")
         )
-        XCTAssertNotNil(firstSession.cachedDraftConversion(for: draftKey))
-        XCTAssertNotNil(firstSession.cachedResolvedConversion(for: resolvedKey))
-        XCTAssertEqual(firstSession.cachedEvaluationPromptTokens(for: "prompt"), [1, 2, 3])
-        XCTAssertNil(secondSession.cachedEvaluation(for: evaluationKey))
-        XCTAssertNil(secondSession.cachedDraftConversion(for: draftKey))
-        XCTAssertNil(secondSession.cachedResolvedConversion(for: resolvedKey))
-        XCTAssertNil(secondSession.cachedEvaluationPromptTokens(for: "prompt"))
+        XCTAssertNotNil(firstCache.cachedDraftConversion(for: draftKey))
+        XCTAssertNotNil(firstCache.cachedResolvedConversion(for: resolvedKey))
+        XCTAssertEqual(firstCache.cachedEvaluationPromptTokens(for: "prompt"), [1, 2, 3])
+        XCTAssertNil(secondCache.cachedEvaluation(for: evaluationKey))
+        XCTAssertNil(secondCache.cachedDraftConversion(for: draftKey))
+        XCTAssertNil(secondCache.cachedResolvedConversion(for: resolvedKey))
+        XCTAssertNil(secondCache.cachedEvaluationPromptTokens(for: "prompt"))
+    }
+
+    func testZenzaiMemoizationCacheSurvivesStopComposition() {
+        let converter = KanaKanjiConverter.withoutDictionary()
+        let cache = converter.zenzaiMemoizationCache
+
+        converter.stopComposition()
+
+        XCTAssertTrue(cache === converter.zenzaiMemoizationCache)
+    }
+
+    func testZenzaiMemoizationCacheIsScopedToConverterAndCanBePurged() {
+        let firstConverter = KanaKanjiConverter.withoutDictionary()
+        let secondConverter = KanaKanjiConverter.withoutDictionary()
+        let originalCache = firstConverter.zenzaiMemoizationCache
+
+        XCTAssertFalse(originalCache === secondConverter.zenzaiMemoizationCache)
+
+        firstConverter.purgeZenzaiMemoizationCache()
+
+        XCTAssertFalse(originalCache === firstConverter.zenzaiMemoizationCache)
     }
 
     func testZenzInferenceThreadCountUsesPerformanceClusterOnDarwin() {

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -126,6 +126,44 @@ final class ZenzaiTests: XCTestCase {
         )
     }
 
+    /// azooKey for iOSのDirect入力で使われる主要設定を再現する。
+    ///
+    /// 辞書・Zenzaiの候補評価だけを測る簡略設定では、llama.cpp更新による実端末上の
+    /// 逐次入力regressionを捕捉できなかった。prediction、learning、left contextを
+    /// 有効にした状態で、文字数の増加に伴う各requestのlatencyを観測する。
+    private func iOSDirectInputOptions() -> ConvertRequestOptions {
+        .init(
+            N_best: 10,
+            requireJapanesePrediction: .autoMix,
+            requireEnglishPrediction: .autoMix,
+            keyboardLanguage: .ja_JP,
+            englishCandidateInRoman2KanaInput: true,
+            fullWidthRomanCandidate: true,
+            halfWidthKanaCandidate: true,
+            learningType: .inputAndOutput,
+            maxMemoryCount: 65_536,
+            shouldResetMemory: false,
+            memoryDirectoryURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("azookey-ios-direct-benchmark-memory"),
+            sharedContainerURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("azookey-ios-direct-benchmark-shared"),
+            textReplacer: .empty,
+            specialCandidateProviders: [],
+            zenzaiMode: .on(
+                weight: URL(
+                    fileURLWithPath: "/Library/Input Methods/azooKeyMac.app/Contents/Resources/ggml-model-Q5_K_M.gguf"
+                ),
+                inferenceLimit: 1,
+                personalizationMode: nil,
+                versionDependentMode: .v3(
+                    .init(leftSideContext: "今日は", maxLeftSideContextLength: 20)
+                )
+            ),
+            typoCorrectionMode: .automatic,
+            metadata: .init(versionString: "azooKey iOS benchmark")
+        )
+    }
+
     func testIncrementalLatticeMatchesFullRebuildForRomanAndAZIKTailRewrites() {
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
         let kanaKanji = Kana2Kanji(dicdataStore: dicdataStore)
@@ -390,6 +428,32 @@ final class ZenzaiTests: XCTestCase {
                         + " predictionHits=\(predictionHitCount)"
                 )
             }
+        }
+    }
+
+    @MainActor
+    func testIOSDirectIncrementalInput() throws {
+        let converter = KanaKanjiConverter.withDefaultDictionary()
+        let options = self.iOSDirectInputOptions()
+        let profilesLatency = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1"
+        var latencies: [Double]? = profilesLatency ? [] : nil
+        var composingText = ComposingText()
+        var finalResult: ConversionResult?
+
+        for character in "かなかんじへんかんをためしています" {
+            composingText.insertAtCursorPosition(String(character), inputStyle: .direct)
+            finalResult = self.measuredRequestCandidates(
+                converter,
+                composingText: composingText,
+                options: options,
+                latencies: &latencies
+            )
+        }
+
+        XCTAssertFalse(finalResult?.mainResults.isEmpty ?? true)
+        self.reportLatencies(latencies, label: "iOS Direct incremental inferenceLimit=1")
+        if let latencies {
+            print("[ZenzaiIOSDirect] samplesMs=\(latencies)")
         }
     }
 

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -5,6 +5,12 @@ import XCTest
 
 #if Zenzai || ZenzaiCPU
 final class ZenzaiTests: XCTestCase {
+    private struct DesktopPredictionScenario {
+        var label: String
+        var leftSideContext: String
+        var input: String
+    }
+
     private func measuredRequestCandidates(
         _ converter: KanaKanjiConverter,
         composingText: ComposingText,
@@ -73,6 +79,50 @@ final class ZenzaiTests: XCTestCase {
             ),
             typoCorrectionMode: .automatic,
             metadata: nil
+        )
+    }
+
+    /// azooKeyDesktopの`SegmentsManager.options`が予測入力を有効にしたときの設定を再現する。
+    ///
+    /// Desktopでは各キー入力のたびにJapanese/English predictionを`.manualMix`で要求し、
+    /// Zenzaiの予測フォールバックも常時有効にする。既定の推論上限は5である。
+    /// 学習とpersonalizationだけはbenchmark結果を端末固有データから分離するため無効化する。
+    private func desktopPredictiveInputOptions(
+        leftSideContext: String?,
+        rightSideContext: String? = nil
+    ) -> ConvertRequestOptions {
+        .init(
+            N_best: 10,
+            requireJapanesePrediction: .manualMix,
+            requireEnglishPrediction: .manualMix,
+            keyboardLanguage: .ja_JP,
+            englishCandidateInRoman2KanaInput: false,
+            fullWidthRomanCandidate: true,
+            halfWidthKanaCandidate: false,
+            learningType: .nothing,
+            maxMemoryCount: 0,
+            shouldResetMemory: false,
+            memoryDirectoryURL: URL(fileURLWithPath: ""),
+            sharedContainerURL: URL(fileURLWithPath: ""),
+            textReplacer: .withDefaultEmojiDictionary(),
+            specialCandidateProviders: KanaKanjiConverter.defaultSpecialCandidateProviders,
+            zenzaiMode: .on(
+                weight: URL(fileURLWithPath: "/Library/Input Methods/azooKeyMac.app/Contents/Resources/ggml-model-Q5_K_M.gguf"),
+                inferenceLimit: 5,
+                requestRichCandidates: false,
+                personalizationMode: .none,
+                versionDependentMode: .v3(
+                    .init(
+                        profile: "",
+                        leftSideContext: leftSideContext,
+                        rightSideContext: rightSideContext,
+                        enableAlignmentSeparator: true
+                    )
+                )
+            ),
+            experimentalZenzaiPredictiveInput: true,
+            typoCorrectionMode: .automatic,
+            metadata: .init(versionString: "azooKey on macOS (benchmark)")
         )
     }
 
@@ -275,6 +325,99 @@ final class ZenzaiTests: XCTestCase {
                 latencies,
                 label: "AZIK inferenceLimit=\(self.inferenceLimitLabel(inferenceLimit))"
             )
+        }
+    }
+
+    @MainActor
+    func testDesktopPredictiveInput_Roman2Kana() throws {
+        // azooKeyDesktopの既定入力方式（Roman2Kana）で、予測入力を有効にしたまま
+        // 1キーずつrequestCandidatesを呼ぶ実利用経路を測る。
+        // 通常の辞書予測が効きやすい入力と、Zenzai fallbackへ進みやすい入力を分けて
+        // reportし、片方だけの最適化でbenchmarkを通すことを防ぐ。
+        let scenarios: [DesktopPredictionScenario] = [
+            .init(
+                label: "dictionary-friendly",
+                leftSideContext: "今日はかな漢字変換について説明します。",
+                input: "kanakanjihenkannoseinouwokakuninsuru"
+            ),
+            .init(
+                label: "fallback-heavy",
+                leftSideContext: "予測変換、個人的には使う機能になってきたけど、",
+                input: "aiueokakikukeko"
+            )
+        ]
+        let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        let profilesLatency = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1"
+
+        for scenario in scenarios {
+            // 各scenarioは独立したDesktop変換セッションとして扱う。結果LRUや
+            // predictive input cacheを別scenarioから持ち越さない。
+            let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
+            let options = self.desktopPredictiveInputOptions(leftSideContext: scenario.leftSideContext)
+            var composingText = ComposingText()
+            var latencies: [Double]? = profilesLatency ? [] : nil
+            var predictionHitCount = 0
+            var finalResult: ConversionResult?
+
+            for character in scenario.input {
+                composingText.insertAtCursorPosition(String(character), inputStyle: .roman2kana)
+                let result = self.measuredRequestCandidates(
+                    converter,
+                    composingText: composingText,
+                    options: options,
+                    latencies: &latencies
+                )
+                if !result.predictionResults.isEmpty {
+                    predictionHitCount += 1
+                }
+                finalResult = result
+            }
+
+            XCTAssertFalse(finalResult?.mainResults.isEmpty ?? true)
+            XCTAssertGreaterThan(
+                predictionHitCount,
+                0,
+                "Desktop prediction path was not exercised for \(scenario.label)"
+            )
+            self.reportLatencies(
+                latencies,
+                label: "DesktopPrediction Roman2Kana \(scenario.label) inferenceLimit=5"
+            )
+            if profilesLatency {
+                print(
+                    "[ZenzaiPrediction] Roman2Kana \(scenario.label)"
+                        + " requests=\(scenario.input.count)"
+                        + " predictionHits=\(predictionHitCount)"
+                )
+            }
+        }
+    }
+
+    @MainActor
+    func testRepeatedCompositionMemoization() throws {
+        // 実アプリでは同じKanaKanjiConverterを保持したまま、変換確定ごとに
+        // stopComposition()を呼ぶ。純粋なメモ化結果はこの境界を跨いで再利用する
+        // 設計なので、iterationごとにconverterを作り直してはいけない。
+        let converter = KanaKanjiConverter.withDefaultDictionary()
+        let profilesLatency = ProcessInfo.processInfo.environment["ZENZAI_PROFILE_LATENCY"] == "1"
+        var latencies: [Double]? = profilesLatency ? [] : nil
+
+        for _ in 1 ... 5 {
+            var composingText = ComposingText()
+            composingText.insertAtCursorPosition("かなかんじへんかん", inputStyle: .direct)
+            let result = self.measuredRequestCandidates(
+                converter,
+                composingText: composingText,
+                options: self.requestOptions(inferenceLimit: 1, leftSideContext: ""),
+                latencies: &latencies
+            )
+            XCTAssertFalse(result.mainResults.isEmpty)
+            converter.stopComposition()
+        }
+
+        self.reportLatencies(latencies, label: "RepeatedComposition Direct inferenceLimit=1")
+        if let latencies {
+            print("[ZenzaiMemoization] repeatedComposition samplesMs=\(latencies)")
         }
     }
 


### PR DESCRIPTION
## 概要

#350 マージ後、azooKey for iOSのDirect入力が数文字後から重くなる回帰が確認されました。

実端末でコミットを二分した結果、`0e67a1f21d4a2baea65c2152029fff9ae2adfcee` は高速で、その直後の `db4632fec683345facbeff03f50d312a15d3af94` から低速になることが確認できました。回帰境界はllama.cpp b4846からb9637への更新と、それに伴うcontext / memory API移行です。b9637内部の単一原因までは特定していません。

このPRではiOS 17の最低要件と#350の変換最適化を維持したまま、llama.cpp連携を実績のあるb4846へ戻します。また、別件として判明した `stopComposition()` 境界でのメモ化キャッシュ破棄も修正します。

## 変更内容

### Direct入力の性能復旧

- llama.cpp XCFrameworkをb9637からb4846へ戻す
- KV cache操作をb4846のAPIへ戻す
- b9637固有のcontext、memory、weight repack設定を削除
- llama mockも実際に利用するb4846 APIへ合わせる
- iOSの最低要件は17のまま維持
- azooKey for iOS相当のDirect逐次入力ベンチマークを追加
  - `N_best = 10`
  - Japanese / English prediction = `.autoMix`
  - learning = `.inputAndOutput`
  - `inferenceLimit = 1`
  - 左文脈最大20文字

### b4846を固定する理由とトレードオフ

b9637が常に遅いわけではありません。macOS CPUではApple Silicon向けruntime weight repackによって高速化しますが、そのためにGGUFのfile-backed mmapとは別のanonymous bufferを必要とします。

M2 Pro / release / 同一Direct逐次入力、初回requestを除く5回平均:

| 構成 | 平均latency |
| --- | ---: |
| b9637 CPU・repack有効 | 7.18 ms/request |
| b9637 CPU・repack無効 | 10.59 ms/request |
| b4846 CPU | 10.78 ms/request |
| b9637 GPU | 約9.56 ms/request |
| b4846 GPU | 約9.00 ms/request |

- b9637のrepack有効時は `CPU_Mapped 66.65 MiB` に加えて `CPU_REPACK 63.77 MiB` を保持する
- `CPU_REPACK` はmmapではなく `ggml_aligned_malloc()` で確保されるため、iOSのmemory footprintへ実質的に加算される
- b9637 CPUの初回requestはrepack込みで約96 ms、b4846とrepack無効b9637は約35 ms
- repackを無効化するとmacOS CPUでのb9637の優位性はほぼ消える
- macOS CPUをb4846へ戻すとsteady-stateは約1.5倍遅くなるが、azooKeyDesktopはGPU構成を使用し、その経路ではb4846の性能悪化を確認していない
- b9637 GPUではテストprocess終了時にMetal residency-setのassertも確認した

`db4632f` 時点ではiOSでもrepackが有効でしたが実機で低速でした。後続変更でrepackを無効化してもiOSのDirect入力回帰は残り、b4846へ戻したこのPRで高速化が実機確認されました。したがって現時点では、iOSの速度・メモリ・backend lifecycleを優先してb4846を固定します。

b9637以降を再検討する条件は以下です。

- iOSのsmall-batch / incremental入力回帰を実機で解消できること
- runtime repackの追加約64MiBを回避するか、iOSのmemory budget内で許容できること
- Metal backendの終了処理を安定させること
- CPU・GPU・iOS実機の同一ベンチマークで再比較すること

### キャッシュ寿命の修正

- evaluation / draft / resolved conversion / prompt tokenの各キャッシュをConverter単位で所有
- `stopComposition()` ではcomposition固有のKV cache・ラティス・予測入力状態だけを終了し、純粋なメモ化結果は保持
- 別Converter間ではキャッシュを共有しない
- scratch sessionでも同一Converterのメモ化キャッシュを利用
- モデルURL変更時はメモ化キャッシュを自動破棄
- メモリ警告などに使える `purgeZenzaiMemoizationCache()` を追加
- `stopComposition()` を跨ぐ再利用とConverter間の分離をユニットテストで固定

辞書変更時の一律purgeは行いません。評価キーは入力・文脈・候補・制約を含み、学習・動的辞書・ユーザ辞書が有効な経路ではdraft / resolved cache自体を利用しないためです。

## その他の計測結果

M2 Pro / release / ZenzaiCPU / iOS相当Direct逐次入力 / inferenceLimit=1、5回:

- average: 11.86〜14.22 ms / request
- 中央のrun: 12.09 ms / request

同一Converterで `変換 → stopComposition()` を5回繰り返した結果:

- 初回: 58.57 ms
- 以降: 0.35 / 0.31 / 0.30 / 0.30 ms

## 検証

- 最新PRを組み込んだazooKey for iOS実機でDirect入力の高速化を確認
- `xcrun swift test -c release --traits ZenzaiCPU --filter ZenzaiTests`（9 tests passed）
- `xcrun swift test -c release --filter ZenzPromptBuilderTests`（18 tests passed）
- `ZENZAI_PROFILE_LATENCY=1 xcrun swift test -c release --traits ZenzaiCPU --filter ZenzaiTests.testIOSDirectIncrementalInput`（5回）
- `ZENZAI_PROFILE_LATENCY=1 xcrun swift test -c release --traits Zenzai --filter ZenzaiTests.testIOSDirectIncrementalInput`
- `xcrun swift build -c release --traits ZenzaiCPU --triple arm64-apple-ios17.0-simulator --sdk <iPhoneSimulator SDK>`
- `xcodebuild -scheme KanaKanjiConverterModule -destination 'generic/platform=iOS Simulator' -configuration Release build`

## 呼び出し側への影響

既存の `stopComposition()` 呼び出しは変更不要です。メモリ警告時に再計算可能なキャッシュを積極的に解放したい場合のみ、新しい `purgeZenzaiMemoizationCache()` を呼べます。
