### PR TITLE
fix(zenzai): Roman2Kanaの未評価draft固定による変換デグレを修正

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -5,10 +5,17 @@ import SwiftUtils
 
 extension Kana2Kanji {
     struct ZenzaiCache {
-        init(_ inputData: ComposingText, constraint: PrefixConstraint, satisfyingCandidate: Candidate?, lattice: Lattice? = nil) {
+        init(
+            _ inputData: ComposingText,
+            constraint: PrefixConstraint,
+            satisfyingCandidate: Candidate?,
+            evaluatedSatisfyingCandidate: Candidate? = nil,
+            lattice: Lattice? = nil
+        ) {
             self.inputData = inputData
             self.prefixConstraint = constraint
             self.satisfyingCandidate = satisfyingCandidate
+            self.evaluatedSatisfyingCandidate = evaluatedSatisfyingCandidate
             self.cachedLattice = lattice
             self.cachedLatticeInputData = lattice == nil ? nil : inputData
         }
@@ -17,18 +24,21 @@ extension Kana2Kanji {
             _ inputData: ComposingText,
             constraint: PrefixConstraint,
             satisfyingCandidate: Candidate?,
+            evaluatedSatisfyingCandidate: Candidate?,
             cachedLattice: Lattice?,
             cachedLatticeInputData: ComposingText?
         ) {
             self.inputData = inputData
             self.prefixConstraint = constraint
             self.satisfyingCandidate = satisfyingCandidate
+            self.evaluatedSatisfyingCandidate = evaluatedSatisfyingCandidate
             self.cachedLattice = cachedLattice
             self.cachedLatticeInputData = cachedLatticeInputData
         }
 
         private var prefixConstraint: PrefixConstraint
         private var satisfyingCandidate: Candidate?
+        private(set) var evaluatedSatisfyingCandidate: Candidate?
         private var inputData: ComposingText
         private var cachedLattice: Lattice?
         private var cachedLatticeInputData: ComposingText?
@@ -44,6 +54,7 @@ extension Kana2Kanji {
                 newInputData,
                 constraint: constraint,
                 satisfyingCandidate: satisfyingCandidate,
+                evaluatedSatisfyingCandidate: satisfyingCandidate,
                 cachedLattice: self.cachedLattice,
                 cachedLatticeInputData: self.cachedLatticeInputData
             )
@@ -171,7 +182,8 @@ extension Kana2Kanji {
             ) ?? ZenzaiCache(
                 latticeInputData,
                 constraint: cached.prefixConstraint,
-                satisfyingCandidate: cached.satisfyingCandidate
+                satisfyingCandidate: cached.satisfyingCandidate,
+                evaluatedSatisfyingCandidate: cached.satisfyingCandidate
             )
             return (
                 eosNode,
@@ -187,12 +199,14 @@ extension Kana2Kanji {
         var insertedCandidates: [(RegisteredNode, Candidate)] = []
         func makeCache(
             constraint: PrefixConstraint,
-            satisfyingCandidate: Candidate?
+            satisfyingCandidate: Candidate?,
+            evaluatedSatisfyingCandidate: Candidate? = nil
         ) -> ZenzaiCache {
             ZenzaiCache(
                 latticeInputData,
                 constraint: constraint,
                 satisfyingCandidate: satisfyingCandidate,
+                evaluatedSatisfyingCandidate: evaluatedSatisfyingCandidate,
                 lattice: latticeIsComplete ? lattice : nil
             )
         }
@@ -325,11 +339,20 @@ extension Kana2Kanji {
                 if defersEvaluationForPendingInput {
                     // ローマ字表で未確定のsuffixは、次のキーでかなへ置換される。
                     // モデルが未確定ASCIIを評価しても結果を再利用できないため、
-                    // かな列が確定するまで辞書変換結果を保持する。
+                    // かな列が確定するまで評価を省略する。未評価のdraftは制約へ
+                    // 昇格させず、現在の入力にも適用できた直前のLM承認候補だけを
+                    // stable prefixとして引き継ぐ。
+                    let evaluatedCandidate = constraint.isEmpty
+                        ? nil
+                        : zenzaiCache?.evaluatedSatisfyingCandidate
                     return (
                         eosNode,
                         lattice,
-                        makeCache(constraint: constraint, satisfyingCandidate: candidate)
+                        makeCache(
+                            constraint: constraint,
+                            satisfyingCandidate: evaluatedCandidate,
+                            evaluatedSatisfyingCandidate: evaluatedCandidate
+                        )
                     )
                 }
                 let reviewResult = zenz.candidateEvaluate(
@@ -420,7 +443,15 @@ extension Kana2Kanji {
                                 for: resolvedConversionCacheKey
                             )
                         }
-                        return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: candidate))
+                        return (
+                            eosNode,
+                            lattice,
+                            makeCache(
+                                constraint: constraint,
+                                satisfyingCandidate: candidate,
+                                evaluatedSatisfyingCandidate: candidate
+                            )
+                        )
                     } else {
                         return (eosNode, lattice, makeCache(constraint: constraint, satisfyingCandidate: nil))
                     }

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -305,6 +305,23 @@ final class ZenzaiTests: XCTestCase {
     }
 
     @MainActor
+    func testGradualConversion_Roman2KanaDoesNotPromoteUnevaluatedDraft() throws {
+        let converter = KanaKanjiConverter.withDefaultDictionary()
+        var options = self.requestOptions(inferenceLimit: 5)
+        options.typoCorrectionMode = .disabled
+        var composingText = ComposingText()
+        var result: ConversionResult?
+
+        for character in "mizuwonomunda" {
+            composingText.insertAtCursorPosition(String(character), inputStyle: .roman2kana)
+            result = converter.requestCandidates(composingText, options: options)
+        }
+
+        XCTAssertEqual(composingText.convertTarget, "みずをのむんだ")
+        XCTAssertEqual(result?.mainResults.first?.text, "水を飲むんだ")
+    }
+
+    @MainActor
     func testGradualConversion() throws {
         // 辞書は先に読み込んでおく（純粋な比較のため）
         let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)


### PR DESCRIPTION
## 概要

Roman2Kana/AZIKの逐次入力で、未確定ローマ字に対するLM評価を省略した際、未評価の辞書draftが次回入力のprefix constraintへ昇格していた問題を修正します。

未評価draftとLM承認済み候補をキャッシュ上で区別し、未確定suffixでは現在の入力にも適用できる直前のLM承認済みprefixだけを引き継ぎます。LM評価の省略自体は維持します。

## 背景・原因

`mizuwonomunda` を1キーずつ入力すると、同じ文字列の一括変換では `水を飲むんだ` になる一方、逐次入力では `水をのむんだ` などへデグレする場合がありました。Zenzai typo correctionを無効にしても再現します。

未確定の `m` / `n` などでは、次のキーでかなへ置換されるためLM評価を省略しています。その省略時に得た辞書draftを `satisfyingCandidate` として保存していたため、LMが承認していない表記まで次回の制約として固定されていました。

## 変更内容

- `ZenzaiCache` にLM評価済みの候補を独立して保持
- LMのpass結果とresolved conversion cacheの結果だけを評価済み候補として記録
- 未確定suffixでは未評価draftを破棄し、適用可能な評価済みprefixだけを継承
- `mizuwonomunda → 水を飲むんだ` の回帰テストを追加
  - typo correctionは明示的に無効化

## 性能

M2 Pro / release / 各3回のaverage latency中央値。Roman2Kana、96状態、`inferenceLimit=5`。

| 実装 | CPU | GPU | 変換品質 |
|---|---:|---:|---|
| PR #350以前 | 34.09 ms/key | 20.13 ms/key | 正常 |
| 未評価draftを固定する高速版 | 12.06 ms/key | 7.43 ms/key | デグレあり |
| 評価済みprefixを全て破棄する単純修正 | 29.49 ms/key | 15.45 ms/key | 正常 |
| 本PR | 12.89 ms/key | 8.26 ms/key | 正常 |

本PRは単純修正比でCPU約56%、GPU約47% latencyを削減しています。デグレのある高速版との差はCPU約7%、GPU約11%です。

Desktop予測入力ベンチでは、デグレのある高速版比でCPU約6〜16%、GPU約0〜11%のlatency増に収まっています。

## 検証

- `xcrun swift test -c release --traits ZenzaiCPU --filter ZenzaiTests`
  - 10件成功、計測用1件skip
- `xcrun swift test -c release --traits ZenzaiCPU --filter 'ZenzaiTests/test(GradualConversion_Roman2KanaDoesNotPromoteUnevaluatedDraft|GradualConversion_AZIK)$'`
- `xcrun swift test -c release --traits Zenzai --filter 'ZenzaiTests/test(GradualConversion_Roman2KanaDoesNotPromoteUnevaluatedDraft|GradualConversion_AZIK)$'`
- CPU/GPUでRoman2KanaおよびDesktop予測入力ベンチを各3回実施
