### PR TITLE
feat: 受け入れた予測候補の表記を先頭の制約として引き継ぐ

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Core/FullInputProcessingWithPrefixConstraint.swift
@@ -27,6 +27,12 @@ extension Kana2Kanji {
         return (matched, total)
     }
 
+    /// 固定された表記は、学習データやユーザ辞書由来のノードにも制約として掛ける。
+    /// 経路の表記が固定された byte 数に達するまで、制約と一致していることを求める。
+    private func matchesFixedPrefix(matched: Int, total: Int, fixedByteCount: Int) -> Bool {
+        matched >= min(total, fixedByteCount)
+    }
+
     // Extend match with next word starting from current matched index
     private func extendMatched(
         matched: Int,
@@ -109,6 +115,7 @@ extension Kana2Kanji {
         }
         let constraintBytes = constraint.constraint
         let constraintLength = constraintBytes.count
+        let fixedByteCount = constraint.fixedPrefix?.byteCount ?? 0
         let enforcesConstraintOnStaticDictionary = !constraint.ignoreMemoryAndUserDictionary
         // 「i文字目から始まるnodes」に対して
         for (isHead, nodeArray) in lattice.indexedNodes(indices: latticeIndices) {
@@ -142,6 +149,8 @@ extension Kana2Kanji {
                             guard condition else {
                                 continue
                             }
+                        } else if !self.matchesFixedPrefix(matched: matchState.matched, total: matchState.total, fixedByteCount: fixedByteCount) {
+                            continue
                         }
                         let newNode = node.getRegisteredNode(
                             0,
@@ -190,6 +199,16 @@ extension Kana2Kanji {
                             guard isCompatible else {
                                 continue
                             }
+                        } else {
+                            let (matched, _) = self.extendMatched(
+                                matched: matchState.matched,
+                                nextWord: nextNode.data.word,
+                                constraintBytes: constraintBytes
+                            )
+                            let newTotal = matchState.total + nextNode.data.word.utf8.count
+                            guard self.matchesFixedPrefix(matched: matched, total: newTotal, fixedByteCount: fixedByteCount) else {
+                                continue
+                            }
                         }
                         let newNode = node.getRegisteredNode(
                             0,
@@ -235,6 +254,8 @@ extension Kana2Kanji {
                             guard condition else {
                                 continue
                             }
+                        } else if !self.matchesFixedPrefix(matched: mtPerPrev[index].matched, total: mtPerPrev[index].total, fixedByteCount: fixedByteCount) {
+                            continue
                         }
                         let newnode: RegisteredNode = node.getRegisteredNode(
                             index,
@@ -300,6 +321,13 @@ extension Kana2Kanji {
                                         || (newTotal <= constraintLength && matchedExt == newTotal)
                                 }
                                 guard ok else {
+                                    continue
+                                }
+                            } else {
+                                let (matchedPrev, totalPrev) = mtPerPrev[index]
+                                let (matchedExt, _) = self.extendMatched(matched: matchedPrev, nextWord: nextnode.data.word, constraintBytes: constraintBytes)
+                                let newTotal = totalPrev + nextnode.data.word.utf8.count
+                                guard self.matchesFixedPrefix(matched: matchedExt, total: newTotal, fixedByteCount: fixedByteCount) else {
                                     continue
                                 }
                             }

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -446,15 +446,16 @@ struct ZenzCandidateEvaluator {
         }
     }
 
-    /// `data` の先頭から、表記が `byteCount` byte に達するまでの要素を落とす
-    private static func droppingFixedData(_ data: [DicdataElement], byteCount: Int) -> [DicdataElement] {
+    /// `data` の先頭から、表記全体が固定部分に収まる要素だけを落とす
+    static func droppingFixedData(_ data: [DicdataElement], byteCount: Int) -> [DicdataElement] {
         var coveredByteCount = 0
         return Array(
             data.drop { element in
-                guard coveredByteCount < byteCount else {
+                let nextCoveredByteCount = coveredByteCount + element.word.utf8.count
+                guard nextCoveredByteCount <= byteCount else {
                     return false
                 }
-                coveredByteCount += element.word.utf8.count
+                coveredByteCount = nextCoveredByteCount
                 return true
             }
         )

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/Zenz/ZenzCandidateEvaluator.swift
@@ -89,6 +89,55 @@ struct ZenzCandidateEvaluator {
         versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
         memoizationCache: ZenzaiMemoizationCache
     ) -> CandidateEvaluationResult {
+        // 固定された部分は、表記を左文脈に移し、読みを入力から除いて、残りだけを評価する。
+        // モデルは固定された表記が読みを消費したことを知らないので、残したまま評価すると続きの判断がずれる。
+        guard let fixedPrefix = prefixConstraint.fixedPrefix,
+              candidate.text.utf8.count >= fixedPrefix.byteCount,
+              input.count >= fixedPrefix.rubyCount else {
+            return self.evaluateAsIs(
+                context: context,
+                input: input,
+                inputCursorPosition: inputCursorPosition,
+                candidate: candidate,
+                requestRichCandidates: requestRichCandidates,
+                prefixConstraint: prefixConstraint,
+                personalizationMode: personalizationMode,
+                versionDependentConfig: versionDependentConfig,
+                memoizationCache: memoizationCache
+            )
+        }
+        let fixed = Array(prefixConstraint.constraint.prefix(fixedPrefix.byteCount))
+        var remainingCandidate = candidate
+        remainingCandidate.text = String(decoding: candidate.text.utf8.dropFirst(fixedPrefix.byteCount), as: UTF8.self)
+        remainingCandidate.data = self.droppingFixedData(candidate.data, byteCount: fixedPrefix.byteCount)
+        var remainingConstraint = prefixConstraint
+        remainingConstraint.constraint = Array(prefixConstraint.constraint.dropFirst(fixedPrefix.byteCount))
+        remainingConstraint.fixedPrefix = nil
+        let result = self.evaluateAsIs(
+            context: context,
+            input: String(input.dropFirst(fixedPrefix.rubyCount)),
+            inputCursorPosition: inputCursorPosition.map { $0 - fixedPrefix.rubyCount },
+            candidate: remainingCandidate,
+            requestRichCandidates: requestRichCandidates,
+            prefixConstraint: remainingConstraint,
+            personalizationMode: personalizationMode,
+            versionDependentConfig: self.appendingLeftSideContext(String(decoding: fixed, as: UTF8.self), to: versionDependentConfig),
+            memoizationCache: memoizationCache
+        )
+        return self.prepending(fixed, to: result)
+    }
+
+    private static func evaluateAsIs(
+        context: ZenzContext,
+        input: String,
+        inputCursorPosition: Int? = nil,
+        candidate: Candidate,
+        requestRichCandidates: Bool,
+        prefixConstraint: Kana2Kanji.PrefixConstraint,
+        personalizationMode: (mode: ConvertRequestOptions.ZenzaiMode.PersonalizationMode, base: EfficientNGram, personal: EfficientNGram)?,
+        versionDependentConfig: ConvertRequestOptions.ZenzaiVersionDependentMode,
+        memoizationCache: ZenzaiMemoizationCache
+    ) -> CandidateEvaluationResult {
         debug("Evaluate", candidate)
         var userDictionaryPrompt = ""
         for item in candidate.data where item.metadata.contains(.isFromUserDictionary) {
@@ -394,6 +443,50 @@ struct ZenzCandidateEvaluator {
                 return candidateText + ZenzPromptBuilder.alignmentSeparator
             }
             return candidateText
+        }
+    }
+
+    /// `data` の先頭から、表記が `byteCount` byte に達するまでの要素を落とす
+    private static func droppingFixedData(_ data: [DicdataElement], byteCount: Int) -> [DicdataElement] {
+        var coveredByteCount = 0
+        return Array(
+            data.drop { element in
+                guard coveredByteCount < byteCount else {
+                    return false
+                }
+                coveredByteCount += element.word.utf8.count
+                return true
+            }
+        )
+    }
+
+    private static func appendingLeftSideContext(_ text: String, to config: ConvertRequestOptions.ZenzaiVersionDependentMode) -> ConvertRequestOptions.ZenzaiVersionDependentMode {
+        switch config {
+        case .v2(var mode):
+            mode.leftSideContext = (mode.leftSideContext ?? "") + text
+            return .v2(mode)
+        case .v3(var mode):
+            mode.leftSideContext = (mode.leftSideContext ?? "") + text
+            return .v3(mode)
+        }
+    }
+
+    /// 固定された表記を除いて評価した結果の制約に、その表記を戻す
+    private static func prepending(_ fixed: [UInt8], to result: CandidateEvaluationResult) -> CandidateEvaluationResult {
+        switch result {
+        case .error:
+            return .error
+        case .pass(let score, let alternativeConstraints):
+            return .pass(
+                score: score,
+                alternativeConstraints: alternativeConstraints.map {
+                    .init(probabilityRatio: $0.probabilityRatio, prefixConstraint: fixed + $0.prefixConstraint)
+                }
+            )
+        case .fixRequired(let prefixConstraint):
+            return .fixRequired(prefixConstraint: fixed + prefixConstraint)
+        case .wholeResult(let wholeResult):
+            return .wholeResult(String(decoding: fixed, as: UTF8.self) + wholeResult)
         }
     }
 

--- a/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/ConversionAlgorithms/Zenzai/zenzai.swift
@@ -10,12 +10,14 @@ extension Kana2Kanji {
             constraint: PrefixConstraint,
             satisfyingCandidate: Candidate?,
             evaluatedSatisfyingCandidate: Candidate? = nil,
+            prefixCandidate: Candidate? = nil,
             lattice: Lattice? = nil
         ) {
             self.inputData = inputData
             self.prefixConstraint = constraint
             self.satisfyingCandidate = satisfyingCandidate
             self.evaluatedSatisfyingCandidate = evaluatedSatisfyingCandidate
+            self.prefixCandidate = prefixCandidate
             self.cachedLattice = lattice
             self.cachedLatticeInputData = lattice == nil ? nil : inputData
         }
@@ -25,6 +27,7 @@ extension Kana2Kanji {
             constraint: PrefixConstraint,
             satisfyingCandidate: Candidate?,
             evaluatedSatisfyingCandidate: Candidate?,
+            prefixCandidate: Candidate?,
             cachedLattice: Lattice?,
             cachedLatticeInputData: ComposingText?
         ) {
@@ -32,6 +35,7 @@ extension Kana2Kanji {
             self.prefixConstraint = constraint
             self.satisfyingCandidate = satisfyingCandidate
             self.evaluatedSatisfyingCandidate = evaluatedSatisfyingCandidate
+            self.prefixCandidate = prefixCandidate
             self.cachedLattice = cachedLattice
             self.cachedLatticeInputData = cachedLatticeInputData
         }
@@ -39,6 +43,8 @@ extension Kana2Kanji {
         private var prefixConstraint: PrefixConstraint
         private var satisfyingCandidate: Candidate?
         private(set) var evaluatedSatisfyingCandidate: Candidate?
+        /// 入力の先頭が決まっている候補。読みが入力の先頭に残っている間、表記を固定部分にする。
+        private(set) var prefixCandidate: Candidate?
         private var inputData: ComposingText
         private var cachedLattice: Lattice?
         private var cachedLatticeInputData: ComposingText?
@@ -55,12 +61,60 @@ extension Kana2Kanji {
                 constraint: constraint,
                 satisfyingCandidate: satisfyingCandidate,
                 evaluatedSatisfyingCandidate: satisfyingCandidate,
+                prefixCandidate: self.prefixCandidate(remainingIn: newInputData),
+                cachedLattice: self.cachedLattice,
+                cachedLatticeInputData: self.cachedLatticeInputData
+            )
+        }
+
+        /// 先頭の候補を設定し、以降の変換で先頭の制約として使う。
+        /// 直近のラティスは差分構築用に保持する。
+        func settingPrefixCandidate(_ candidate: Candidate) -> ZenzaiCache {
+            ZenzaiCache(
+                self.inputData,
+                constraint: self.prefixConstraint,
+                satisfyingCandidate: candidate,
+                evaluatedSatisfyingCandidate: candidate,
+                prefixCandidate: candidate,
                 cachedLattice: self.cachedLattice,
                 cachedLatticeInputData: self.cachedLatticeInputData
             )
         }
 
         func getNewConstraint(for newInputData: ComposingText) -> PrefixConstraint {
+            self.fixingPrefix(self.getReplaceableConstraint(for: newInputData), for: newInputData)
+        }
+
+        /// 先頭の候補の読みが入力の先頭にそのまま残っていればその候補。残っていなければ nil で、以降は引き継がない。
+        func prefixCandidate(remainingIn newInputData: ComposingText) -> Candidate? {
+            guard let prefixCandidate,
+                  newInputData.convertTarget.toKatakana().hasPrefix(prefixCandidate.data.map(\.ruby).joined()) else {
+                return nil
+            }
+            return prefixCandidate
+        }
+
+        /// 先頭の候補の読みが入力の先頭にそのまま残っている間、その表記を固定部分にする。
+        /// 制約が表記で始まっていればその長さを固定し、始まっていなければ表記で置き換える。
+        private func fixingPrefix(_ constraint: PrefixConstraint, for newInputData: ComposingText) -> PrefixConstraint {
+            guard let prefixCandidate = self.prefixCandidate(remainingIn: newInputData) else {
+                return constraint
+            }
+            let fixed = Array(prefixCandidate.data.map(\.word).joined().utf8)
+            let fixedPrefix = PrefixConstraint.FixedPrefix(
+                byteCount: fixed.count,
+                rubyCount: prefixCandidate.data.map(\.ruby).joined().count
+            )
+            if constraint.constraint.hasPrefix(fixed) {
+                var fixedConstraint = constraint
+                fixedConstraint.fixedPrefix = fixedPrefix
+                return fixedConstraint
+            }
+            return PrefixConstraint(fixed, fixedPrefix: fixedPrefix)
+        }
+
+        /// モデルの評価で置き換わりうる制約。
+        private func getReplaceableConstraint(for newInputData: ComposingText) -> PrefixConstraint {
             if let satisfyingCandidate {
                 var current = newInputData.convertTarget.toKatakana()[...]
                 var constraint = [UInt8]()
@@ -101,18 +155,28 @@ extension Kana2Kanji {
     }
 
     struct PrefixConstraint: Sendable, Equatable, Hashable, CustomStringConvertible {
-        init(_ constraint: [UInt8], hasEOS: Bool = false, ignoreMemoryAndUserDictionary: Bool = false) {
+        /// 先頭の決まっている部分。モデルはこの表記を左文脈、この読みを入力済みとして扱い、評価しない。
+        struct FixedPrefix: Sendable, Equatable, Hashable {
+            /// `constraint` の先頭のうち、固定された表記の byte 数
+            var byteCount: Int
+            /// 入力 (カタカナ) の先頭のうち、その表記が読んだ文字数
+            var rubyCount: Int
+        }
+
+        init(_ constraint: [UInt8], hasEOS: Bool = false, ignoreMemoryAndUserDictionary: Bool = false, fixedPrefix: FixedPrefix? = nil) {
             self.constraint = constraint
             self.hasEOS = hasEOS
             self.ignoreMemoryAndUserDictionary = ignoreMemoryAndUserDictionary
+            self.fixedPrefix = fixedPrefix
         }
 
         var constraint: [UInt8]
         var hasEOS: Bool
         var ignoreMemoryAndUserDictionary: Bool
+        var fixedPrefix: FixedPrefix?
 
         var description: String {
-            "PrefixConstraint(constraint: \"\(String(decoding: self.constraint, as: UTF8.self))\", hasEOS: \(self.hasEOS), ignoreMemoryAndUserDictionary: \(self.ignoreMemoryAndUserDictionary))"
+            "PrefixConstraint(constraint: \"\(String(decoding: self.constraint, as: UTF8.self))\", hasEOS: \(self.hasEOS), ignoreMemoryAndUserDictionary: \(self.ignoreMemoryAndUserDictionary), fixedPrefix: \(String(describing: self.fixedPrefix)))"
         }
 
         var isEmpty: Bool {
@@ -142,6 +206,7 @@ extension Kana2Kanji {
                 inputStyle: inputStyle
             ).droppedSuffixCount > 0
         var constraint = zenzaiCache?.getNewConstraint(for: latticeInputData) ?? PrefixConstraint([])
+        let prefixCandidate = zenzaiCache?.prefixCandidate(remainingIn: latticeInputData)
         let resolvedConversionCacheKey: ZenzResolvedConversionCacheKey? =
             if !requestRichCandidates,
                personalizationMode == nil,
@@ -207,6 +272,7 @@ extension Kana2Kanji {
                 constraint: constraint,
                 satisfyingCandidate: satisfyingCandidate,
                 evaluatedSatisfyingCandidate: evaluatedSatisfyingCandidate,
+                prefixCandidate: prefixCandidate,
                 lattice: latticeIsComplete ? lattice : nil
             )
         }
@@ -502,7 +568,8 @@ extension Kana2Kanji {
             let newConstraint = Self.normalizedZenzConstraint(
                 prefixConstraint,
                 defaultHasEOS: false,
-                ignoreMemoryAndUserDictionary: constraint.ignoreMemoryAndUserDictionary
+                ignoreMemoryAndUserDictionary: constraint.ignoreMemoryAndUserDictionary,
+                fixedPrefix: constraint.fixedPrefix
             )
             if constraint == newConstraint {
                 if !constraint.ignoreMemoryAndUserDictionary, candidates[candidateIndex].data.contains(where: { !$0.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary])}) {
@@ -542,7 +609,8 @@ extension Kana2Kanji {
             let newConstraint = Self.normalizedZenzConstraint(
                 Array(wholeConstraint.utf8),
                 defaultHasEOS: true,
-                ignoreMemoryAndUserDictionary: constraint.ignoreMemoryAndUserDictionary
+                ignoreMemoryAndUserDictionary: constraint.ignoreMemoryAndUserDictionary,
+                fixedPrefix: constraint.fixedPrefix
             )
             // 同じ制約が2回連続で出てきたら諦める
             if constraint == newConstraint {
@@ -584,12 +652,14 @@ extension Kana2Kanji {
     static func normalizedZenzConstraint(
         _ constraintBytes: [UInt8],
         defaultHasEOS: Bool,
-        ignoreMemoryAndUserDictionary: Bool
+        ignoreMemoryAndUserDictionary: Bool,
+        fixedPrefix: PrefixConstraint.FixedPrefix? = nil
     ) -> PrefixConstraint {
+        // fixedPrefixの byte 数をそのまま引き継げるのは、ZenzCandidateEvaluator.evaluate が結果の先頭に固定された表記を戻すため
         if let prefix = self.prefixBeforeAlignmentSeparator(in: constraintBytes) {
-            return PrefixConstraint(prefix, hasEOS: true, ignoreMemoryAndUserDictionary: ignoreMemoryAndUserDictionary)
+            return PrefixConstraint(prefix, hasEOS: true, ignoreMemoryAndUserDictionary: ignoreMemoryAndUserDictionary, fixedPrefix: fixedPrefix)
         }
-        return PrefixConstraint(constraintBytes, hasEOS: defaultHasEOS, ignoreMemoryAndUserDictionary: ignoreMemoryAndUserDictionary)
+        return PrefixConstraint(constraintBytes, hasEOS: defaultHasEOS, ignoreMemoryAndUserDictionary: ignoreMemoryAndUserDictionary, fixedPrefix: fixedPrefix)
     }
 
     private static func prefixBeforeAlignmentSeparator(in bytes: [UInt8]) -> [UInt8]? {

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/Candidate.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/Candidate.swift
@@ -141,7 +141,7 @@ public enum ComposingCount: Sendable, Equatable {
 }
 
 /// 変換候補のデータ
-public struct Candidate: Sendable {
+public struct Candidate: Sendable, Equatable {
     /// 入力となるテキスト
     public var text: String
     /// 評価値

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -749,6 +749,9 @@ public final class KanaKanjiConverter {
         guard let firstCandidate = predictedResult.mainResults.first else {
             return []
         }
+        if let prefixText, !firstCandidate.text.hasPrefix(prefixText) {
+            return []
+        }
         return [firstCandidate]
     }
 
@@ -862,6 +865,32 @@ public final class KanaKanjiConverter {
         return candidates
     }
 
+    /// `Candidate.text` がテンプレート展開済みでも、辞書内の表記を使って制約できるようにする。
+    private func prefixText(of candidate: Candidate) -> String {
+        let dictionaryText = candidate.data.map(\.word).joined()
+        return dictionaryText.isEmpty ? candidate.text : dictionaryText
+    }
+
+    private func candidates(_ candidates: [Candidate], matchingPrefix prefixText: String?) -> [Candidate] {
+        guard let prefixText else {
+            return candidates
+        }
+        return candidates.filter { $0.text.hasPrefix(prefixText) }
+    }
+
+    /// 確定済みのテンプレート部分は再展開せず、その表示を維持して残りだけを展開する。
+    private func prepareCandidateForResult(_ candidate: inout Candidate, prefixCandidate: Candidate?) {
+        candidate.withActions(self.getAppropriateActions(candidate))
+        if let prefixCandidate {
+            let rawPrefixText = self.prefixText(of: prefixCandidate)
+            if rawPrefixText != prefixCandidate.text, candidate.text.hasPrefix(rawPrefixText) {
+                candidate.text = prefixCandidate.text + String(candidate.text.dropFirst(rawPrefixText.count))
+                candidate.isLearningTarget = false
+            }
+        }
+        candidate.parseTemplate()
+    }
+
     /// ラティスを処理し変換候補の形にまとめる関数
     /// - Parameters:
     ///   - inputData: 変換対象のInputData。
@@ -877,16 +906,20 @@ public final class KanaKanjiConverter {
             $0.lattice = result.lattice
         }
         let inputStyle = inputData.input.last?.inputStyle ?? .direct
+        let prefixCandidate = options.zenzaiMode.enabled ? self.currentSessionState.zenzaiCache?.prefixCandidate : nil
+        // テンプレート候補の `text` は表示用に展開済みなので、ラティスや辞書候補との比較には元の表記を使う。
+        let prefixText = prefixCandidate.map { self.prefixText(of: $0) }
         // 比較的大きい配列（〜1000、2000程度の候補が含まれることがある）
         let clauseResult = result.result.getCandidateData()
         if clauseResult.isEmpty {
             self.invalidateStablePredictionCandidateCache()
-            let candidates = self.getUniqueCandidate(self.getAdditionalCandidate(inputData, options: options))
+            let candidates = self.candidates(
+                self.getUniqueCandidate(self.getAdditionalCandidate(inputData, options: options)),
+                matchingPrefix: prefixText
+            )
             return ConversionResult(mainResults: candidates, predictionResults: [], englishPredictionResults: [], firstClauseResults: candidates)   // アーリーリターン
         }
 
-        // 先頭の候補の表記。予測候補もこの表記で始める
-        let prefixText = options.zenzaiMode.enabled ? self.currentSessionState.zenzaiCache?.prefixCandidate?.text : nil
         // 予測変換用のベスト候補
         var bestCandidateDataForPrediction: CandidateData?
         // 文章全体を変換した場合の候補上位5件を作る（不要なときはlazyで中間配列を避ける）
@@ -926,7 +959,10 @@ public final class KanaKanjiConverter {
 
         if case .完全一致 = options.requestQuery {
             self.invalidateStablePredictionCandidateCache()
-            let merged = self.getUniqueCandidate(wholeSentenceUniqueCandidates.chained(userShortcutsCandidates))
+            let merged = self.candidates(
+                self.getUniqueCandidate(wholeSentenceUniqueCandidates.chained(userShortcutsCandidates)),
+                matchingPrefix: prefixText
+            )
             if options.zenzaiMode.enabled {
                 return ConversionResult(mainResults: consume merged, predictionResults: [], englishPredictionResults: [], firstClauseResults: [])
             } else {
@@ -960,9 +996,12 @@ public final class KanaKanjiConverter {
                 let candidates = self.getUniqueCandidate(
                     self.getPredictionCandidate(bestCandidateDataForPrediction, composingText: inputData, options: options, prefixText: prefixText)
                 ).min(count: 3, sortedBy: {$0.value > $1.value})
-                stablePredictionCandidates = self.stablePredictionCandidates(
-                    composingText: inputData,
-                    inputStyle: inputStyle
+                stablePredictionCandidates = self.candidates(
+                    self.stablePredictionCandidates(
+                        composingText: inputData,
+                        inputStyle: inputStyle
+                    ),
+                    matchingPrefix: prefixText
                 )
                 predictionResults = self.mergeStableCandidates(
                     stableCandidates: stablePredictionCandidates,
@@ -994,12 +1033,15 @@ public final class KanaKanjiConverter {
             // その他のトップレベル変換（先頭に表示されうる変換候補）
             let topLevelAdditionalCandidates = self.getTopLevelAdditionalCandidate(inputData, options: options)
             // best8、foreign_candidates、zeroHintPrediction_candidates、toplevel_additional_candidate、user_shortcuts を混ぜて上位5件を取得する
-            let mixedCandidates = getUniqueCandidate(
-                bestFiveSentenceCandidates
-                    .chained(consume bestThreePredictionCandidates)
-                    .chained(consume foreignCandidates)
-                    .chained(consume topLevelAdditionalCandidates)
-                    .chained(consume userShortcutsCandidates)
+            let mixedCandidates = self.candidates(
+                getUniqueCandidate(
+                    bestFiveSentenceCandidates
+                        .chained(consume bestThreePredictionCandidates)
+                        .chained(consume foreignCandidates)
+                        .chained(consume topLevelAdditionalCandidates)
+                        .chained(consume userShortcutsCandidates)
+                ),
+                matchingPrefix: prefixText
             )
             if options.requireJapanesePrediction.shouldMix {
                 fullCandidates = self.mergeStableCandidates(
@@ -1012,17 +1054,20 @@ public final class KanaKanjiConverter {
             }
         }
         // 文節のみ変換するパターン（上位5件）
-        let uniqueFirstClauseCandidates = self.getUniqueCandidate((consume clauseResult).lazy.map {(candidateData: CandidateData) -> Candidate in
-            let first = candidateData.clauses.first!
-            let count = max(0, first.clause.dataEndIndex)
-            return Candidate(
-                text: first.clause.text,
-                value: first.value,
-                composingCount: first.clause.ranges.reduce(into: .inputCount(0)) { $0 = .composite($0, $1.count) },
-                lastMid: first.clause.mid,
-                data: Array(candidateData.data[0...count])
-            )
-        })
+        let uniqueFirstClauseCandidates = self.candidates(
+            self.getUniqueCandidate((consume clauseResult).lazy.map {(candidateData: CandidateData) -> Candidate in
+                let first = candidateData.clauses.first!
+                let count = max(0, first.clause.dataEndIndex)
+                return Candidate(
+                    text: first.clause.text,
+                    value: first.value,
+                    composingCount: first.clause.ranges.reduce(into: .inputCount(0)) { $0 = .composite($0, $1.count) },
+                    lastMid: first.clause.mid,
+                    data: Array(candidateData.data[0...count])
+                )
+            }),
+            matchingPrefix: prefixText
+        )
 
         var firstClauseResults = uniqueFirstClauseCandidates.min(count: 5) {
             if $0.rubyCount == $1.rubyCount {
@@ -1060,17 +1105,22 @@ public final class KanaKanjiConverter {
                 }
             // その他辞書データに追加する候補
             let additionalCandidates: [Candidate] = self.getAdditionalCandidate(inputData, options: options)
-            var candidates = self.getUniqueCandidate((consume dicCandidates).chained(consume additionalCandidates), seenCandidates: seenCandidate)
-                .sorted {
-                    let count0 = $0.rubyCount
-                    let count1 = $1.rubyCount
-                    return count0 == count1 ? $0.value > $1.value : count0 > count1
-                }
+            var candidates = self.candidates(
+                self.getUniqueCandidate((consume dicCandidates).chained(consume additionalCandidates), seenCandidates: seenCandidate),
+                matchingPrefix: prefixText
+            ).sorted {
+                let count0 = $0.rubyCount
+                let count1 = $1.rubyCount
+                return count0 == count1 ? $0.value > $1.value : count0 > count1
+            }
             for c in candidates {
                 seenCandidate.insert(c.text)
             }
             // 賢く変換するパターン（任意件数）
-            let wiseCandidates = self.getUniqueCandidate(self.getSpecialCandidate(inputData, options: options), seenCandidates: seenCandidate)
+            let wiseCandidates = self.candidates(
+                self.getUniqueCandidate(self.getSpecialCandidate(inputData, options: options), seenCandidates: seenCandidate),
+                matchingPrefix: prefixText
+            )
             // 途中でwise_candidatesを挟む
             candidates.insert(contentsOf: consume wiseCandidates, at: min(5, candidates.endIndex))
             wordCandidates = consume candidates
@@ -1096,17 +1146,17 @@ public final class KanaKanjiConverter {
         result.append(contentsOf: consume firstClauseCandidates)
         result.append(contentsOf: consume wordCandidates)
 
+        result = self.candidates(consume result, matchingPrefix: prefixText)
+        predictionResults = self.candidates(consume predictionResults, matchingPrefix: prefixText)
+
         result.mutatingForEach { item in
-            item.withActions(self.getAppropriateActions(item))
-            item.parseTemplate()
+            self.prepareCandidateForResult(&item, prefixCandidate: prefixCandidate)
         }
         firstClauseResults.mutatingForEach { item in
-            item.withActions(self.getAppropriateActions(item))
-            item.parseTemplate()
+            self.prepareCandidateForResult(&item, prefixCandidate: prefixCandidate)
         }
         predictionResults.mutatingForEach { item in
-            item.withActions(self.getAppropriateActions(item))
-            item.parseTemplate()
+            self.prepareCandidateForResult(&item, prefixCandidate: prefixCandidate)
         }
         englishPredictionResults.mutatingForEach { item in
             item.withActions(self.getAppropriateActions(item))

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -438,6 +438,27 @@ public final class KanaKanjiConverter {
         }
     }
 
+    /// 入力の先頭が決まっている候補を設定する関数
+    /// 以降の変換と予測は、この候補の表記で始まるものだけになる。読みが入力の先頭から消えると外れる。
+    /// - Parameters:
+    ///   - candidate: 先頭の候補。クライアントが受け入れた予測候補 (`ConversionResult.predictionResults`) を渡す。
+    /// - Note:
+    ///   先頭の制約は Zenzai の変換でだけ使われる。
+    public func setPrefixCandidate(_ candidate: Candidate) {
+        // 前のキー入力の予測は先頭を決める前の文脈のものなので捨てる
+        self.invalidateStablePredictionCandidateCache()
+        self.updateCurrentSessionState {
+            $0.zenzaiCache = $0.zenzaiCache?.settingPrefixCandidate(candidate)
+                ?? Kana2Kanji.ZenzaiCache(
+                    $0.previousInputData ?? ComposingText(),
+                    constraint: .init([]),
+                    satisfyingCandidate: candidate,
+                    evaluatedSatisfyingCandidate: candidate,
+                    prefixCandidate: candidate
+                )
+        }
+    }
+
     /// 確定操作後、学習メモリをアップデートする関数。
     /// - Parameters:
     ///   - candidate: 確定された候補。
@@ -619,7 +640,7 @@ public final class KanaKanjiConverter {
     ///   - sums: 変換対象のデータ。
     /// - Returns:
     ///   予測変換候補
-    private func getPredictionCandidate(_ bestCandidateDataForPrediction: consuming CandidateData, composingText: ComposingText, options: ConvertRequestOptions) -> [Candidate] {
+    private func getPredictionCandidate(_ bestCandidateDataForPrediction: consuming CandidateData, composingText: ComposingText, options: ConvertRequestOptions, prefixText: String? = nil) -> [Candidate] {
         // 予測変換は次の方針で行う。
         // prepart: 前半文節 lastPart: 最終文節とする。
         // まず、lastPartがnilであるところから始める
@@ -679,6 +700,10 @@ public final class KanaKanjiConverter {
             )
             print(fullClause.text, predictions)
             candidates.append(contentsOf: consume predictions)
+        }
+        // 辞書の予測は最後の文節を読みで引き直すため、先頭の表記を含まない候補が出る。それは除く
+        if let prefixText {
+            candidates.removeAll { !$0.text.hasPrefix(prefixText) }
         }
         if !candidates.isEmpty {
             return candidates
@@ -860,13 +885,19 @@ public final class KanaKanjiConverter {
             return ConversionResult(mainResults: candidates, predictionResults: [], englishPredictionResults: [], firstClauseResults: candidates)   // アーリーリターン
         }
 
+        // 先頭の候補の表記。予測候補もこの表記で始める
+        let prefixText = options.zenzaiMode.enabled ? self.currentSessionState.zenzaiCache?.prefixCandidate?.text : nil
         // 予測変換用のベスト候補
         var bestCandidateDataForPrediction: CandidateData?
         // 文章全体を変換した場合の候補上位5件を作る（不要なときはlazyで中間配列を避ける）
         let wholeSentenceUniqueCandidates: [Candidate]
         if options.requireJapanesePrediction.isEnabled {
             let clauseResultCandidates = clauseResult.map { self.converter.processClauseCandidate($0) }
-            bestCandidateDataForPrediction = zip(clauseResult, clauseResultCandidates).max {$0.1.value < $1.1.value}!.0
+            let candidatePairs = zip(clauseResult, clauseResultCandidates)
+            let prefixPairs = prefixText.map { text in candidatePairs.filter { $0.1.text.hasPrefix(text) } } ?? []
+            bestCandidateDataForPrediction = prefixPairs.isEmpty
+                ? candidatePairs.max {$0.1.value < $1.1.value}!.0
+                : prefixPairs.max {$0.1.value < $1.1.value}!.0
             wholeSentenceUniqueCandidates = self.getUniqueCandidate(clauseResultCandidates)
         } else {
             wholeSentenceUniqueCandidates = self.getUniqueCandidate(clauseResult.lazy.map { self.converter.processClauseCandidate($0) })
@@ -927,7 +958,7 @@ public final class KanaKanjiConverter {
             var stablePredictionCandidates: [Candidate] = []
             if options.requireJapanesePrediction.isEnabled, let bestCandidateDataForPrediction {
                 let candidates = self.getUniqueCandidate(
-                    self.getPredictionCandidate(bestCandidateDataForPrediction, composingText: inputData, options: options)
+                    self.getPredictionCandidate(bestCandidateDataForPrediction, composingText: inputData, options: options, prefixText: prefixText)
                 ).min(count: 3, sortedBy: {$0.value > $1.value})
                 stablePredictionCandidates = self.stablePredictionCandidates(
                     composingText: inputData,

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/KanaKanjiConverter.swift
@@ -438,13 +438,40 @@ public final class KanaKanjiConverter {
         }
     }
 
-    /// 入力の先頭が決まっている候補を設定する関数
-    /// 以降の変換と予測は、この候補の表記で始まるものだけになる。読みが入力の先頭から消えると外れる。
+    /// 予測候補を未確定入力に受け入れる。
+    /// 候補の残りの読みを入力へ追加し、以降の変換と予測を受け入れた表記で始まるものに制約する。
     /// - Parameters:
-    ///   - candidate: 先頭の候補。クライアントが受け入れた予測候補 (`ConversionResult.predictionResults`) を渡す。
+    ///   - candidate: 受け入れる予測候補。`ConversionResult.predictionResults` の要素を渡す。
+    ///   - composingText: 候補を受け入れる未確定入力。
+    /// - Returns: 候補が現在の入力に適用でき、入力と制約を更新した場合は `true`。それ以外は `false`。
     /// - Note:
-    ///   先頭の制約は Zenzai の変換でだけ使われる。
-    public func setPrefixCandidate(_ candidate: Candidate) {
+    ///   この関数は候補の再計算を行わない。更新後の `composingText` を使って `requestCandidates(_:options:)` を呼び出すこと。
+    ///   受け入れた表記による先頭の制約は Zenzai の変換でだけ使われる。
+    @discardableResult
+    public func acceptPredictionCandidate(_ candidate: Candidate, composingText: inout ComposingText) -> Bool {
+        guard !composingText.isEmpty, composingText.isAtEndIndex else {
+            return false
+        }
+        let candidateRuby = candidate.data.map(\.ruby).joined().toHiragana()
+        guard !candidateRuby.isEmpty else {
+            return false
+        }
+        let inputStyle = composingText.input.last?.inputStyle ?? .direct
+        let source = self.converter.resolvePredictiveInputSource(
+            composingText: composingText,
+            inputStyle: inputStyle
+        )
+        let currentRuby = source.baseConvertTarget.toHiragana()
+        guard candidateRuby.hasPrefix(currentRuby), candidateRuby.count > currentRuby.count else {
+            return false
+        }
+        let remainingRuby = String(candidateRuby.dropFirst(currentRuby.count))
+
+        if source.droppedSuffixCount > 0 {
+            composingText.deleteBackwardFromCursorPosition(count: source.droppedSuffixCount)
+        }
+        composingText.insertAtCursorPosition(remainingRuby, inputStyle: .direct)
+
         // 前のキー入力の予測は先頭を決める前の文脈のものなので捨てる
         self.invalidateStablePredictionCandidateCache()
         self.updateCurrentSessionState {
@@ -457,6 +484,7 @@ public final class KanaKanjiConverter {
                     prefixCandidate: candidate
                 )
         }
+        return true
     }
 
     /// 確定操作後、学習メモリをアップデートする関数。

--- a/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConversionAlgorithms/ZenzPromptBuilderTests.swift
@@ -129,6 +129,55 @@ final class ZenzPromptBuilderTests: XCTestCase {
         XCTAssertEqual(text, "葉\u{EE08}")
     }
 
+    func testDroppingFixedDataKeepsElementCrossingFixedBoundary() {
+        let crossingElement = DicdataElement(
+            word: "←の",
+            ruby: "ヒダリノ",
+            cid: CIDData.一般名詞.cid,
+            mid: MIDData.一般.mid,
+            value: 0,
+            metadata: .isFromUserDictionary
+        )
+        let trailingElement = DicdataElement(
+            word: "候補",
+            ruby: "コウホ",
+            cid: CIDData.一般名詞.cid,
+            mid: MIDData.一般.mid,
+            value: 0
+        )
+
+        let result = ZenzCandidateEvaluator.droppingFixedData(
+            [crossingElement, trailingElement],
+            byteCount: "←".utf8.count
+        )
+
+        XCTAssertEqual(result, [crossingElement, trailingElement])
+    }
+
+    func testDroppingFixedDataDropsElementsCoveredByFixedPrefix() {
+        let fixedElement = DicdataElement(
+            word: "←",
+            ruby: "ヒダリ",
+            cid: CIDData.一般名詞.cid,
+            mid: MIDData.一般.mid,
+            value: 0
+        )
+        let trailingElement = DicdataElement(
+            word: "の",
+            ruby: "ノ",
+            cid: CIDData.一般名詞.cid,
+            mid: MIDData.一般.mid,
+            value: 0
+        )
+
+        let result = ZenzCandidateEvaluator.droppingFixedData(
+            [fixedElement, trailingElement],
+            byteCount: "←".utf8.count
+        )
+
+        XCTAssertEqual(result, [trailingElement])
+    }
+
     func testZenzaiLatticeInputDataUsesPrefixForNonEndCursor() {
         let input = ComposingText(
             convertTargetCursorPosition: 1,

--- a/Tests/KanaKanjiConverterModuleTests/ConverterAPI/PredictiveInputCacheTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterAPI/PredictiveInputCacheTests.swift
@@ -14,6 +14,52 @@ final class PredictiveInputCacheTests: XCTestCase {
         )
     }
 
+    func testAcceptPredictionCandidateAppendsRemainingReading() {
+        let converter = KanaKanjiConverter.withoutDictionary()
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition("ありが", inputStyle: .direct)
+
+        let accepted = converter.acceptPredictionCandidate(
+            self.makeCandidate(text: "ありがとうございます"),
+            composingText: &composingText
+        )
+
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(composingText.convertTarget, "ありがとうございます")
+    }
+
+    func testAcceptPredictionCandidateReplacesPendingRomanSuffix() {
+        let converter = KanaKanjiConverter.withoutDictionary()
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition("arigat", inputStyle: .roman2kana)
+        XCTAssertEqual(composingText.convertTarget, "ありがt")
+
+        let accepted = converter.acceptPredictionCandidate(
+            self.makeCandidate(text: "ありがとう"),
+            composingText: &composingText
+        )
+
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(composingText.convertTarget, "ありがとう")
+    }
+
+    func testAcceptPredictionCandidateRejectsIncompatibleCandidateWithoutMutation() {
+        let converter = KanaKanjiConverter.withoutDictionary()
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition("こんにちは", inputStyle: .direct)
+        let original = composingText
+
+        let accepted = converter.acceptPredictionCandidate(
+            self.makeCandidate(text: "こんばんは"),
+            composingText: &composingText
+        )
+
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(composingText.convertTarget, original.convertTarget)
+        XCTAssertEqual(composingText.convertTargetCursorPosition, original.convertTargetCursorPosition)
+        XCTAssertEqual(composingText.input.map(\.piece), original.input.map(\.piece))
+    }
+
     func testRemainingPredictionReturnsUnconsumedSuffix() {
         let entry = PredictiveInputCacheEntry(
             context: .init(

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -519,6 +519,73 @@ final class ZenzaiTests: XCTestCase {
         }
     }
 
+    func testPrefixCandidateFiltersCandidatesMixedAfterZenzaiConversion() throws {
+        let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        let options = self.requestOptions(inferenceLimit: 0)
+        let accepted = try XCTUnwrap(
+            self.candidate(withText: "←", ofRuby: "ひだり", dicdataStore: dicdataStore, options: options)
+        )
+        let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
+        converter.importDynamicUserDictionary(
+            [],
+            shortcuts: [
+                .init(
+                    word: "左",
+                    ruby: "ヒダリ",
+                    cid: CIDData.一般名詞.cid,
+                    mid: MIDData.一般.mid,
+                    value: 0
+                )
+            ]
+        )
+        converter.setPrefixCandidate(accepted)
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition("ひだり", inputStyle: .direct)
+
+        let result = converter.requestCandidates(composingText, options: options)
+
+        XCTAssertEqual(result.mainResults.first?.text, "←")
+        XCTAssertTrue(result.mainResults.allSatisfy { $0.text.hasPrefix("←") })
+    }
+
+    func testPrefixCandidateUsesUnparsedTemplateTextForPredictions() throws {
+        let template = #"<date format="yyyy年MM月dd日" type="western" language="ja_JP" delta="0" deltaunit="1">"#
+        let converter = KanaKanjiConverter.withDefaultDictionary()
+        converter.importDynamicUserDictionary([
+            .init(
+                word: template,
+                ruby: "キョウ",
+                cid: CIDData.一般名詞.cid,
+                mid: MIDData.一般.mid,
+                value: 0
+            ),
+            .init(
+                word: template + "は晴れ",
+                ruby: "キョウハハレ",
+                cid: CIDData.一般名詞.cid,
+                mid: MIDData.一般.mid,
+                value: 0
+            )
+        ])
+        var options = self.requestOptions(inferenceLimit: 0)
+        options.requireJapanesePrediction = .manualMix
+        options.experimentalZenzaiPredictiveInput = false
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition("きょう", inputStyle: .direct)
+        let initialResult = converter.requestCandidates(composingText, options: options)
+        let accepted = try XCTUnwrap(
+            initialResult.predictionResults.first { $0.data.map(\.word).joined() == template }
+        )
+        XCTAssertTrue(initialResult.predictionResults.contains { $0.data.map(\.word).joined() == template + "は晴れ" })
+
+        converter.setPrefixCandidate(accepted)
+        let nextResult = converter.requestCandidates(composingText, options: options)
+
+        XCTAssertFalse(nextResult.predictionResults.isEmpty)
+        XCTAssertTrue(nextResult.predictionResults.allSatisfy { $0.text.hasPrefix(accepted.text) })
+        XCTAssertTrue(nextResult.predictionResults.contains { $0.text == accepted.text + "は晴れ" })
+    }
+
     private func candidate(withText text: String, ofRuby ruby: String, dicdataStore: DicdataStore, options: ConvertRequestOptions) -> Candidate? {
         var composingText = ComposingText()
         composingText.insertAtCursorPosition(ruby, inputStyle: .direct)

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -508,8 +508,8 @@ final class ZenzaiTests: XCTestCase {
                     ?? self.candidate(withText: testCase.acceptedText, ofRuby: testCase.acceptedRuby, dicdataStore: dicdataStore, options: options),
                 "\(testCase.acceptedText) が候補に無い"
             )
-            converter.setPrefixCandidate(accepted)
-            composingText.insertAtCursorPosition(String(testCase.acceptedRuby.dropFirst(testCase.input.count)), inputStyle: .direct)
+            XCTAssertTrue(converter.acceptPredictionCandidate(accepted, composingText: &composingText))
+            XCTAssertEqual(composingText.convertTarget, testCase.acceptedRuby)
             let next = converter.requestCandidates(composingText, options: options)
             XCTAssertEqual(next.mainResults.first?.text, testCase.acceptedText, "\(testCase.input) → \(testCase.acceptedText)")
             XCTAssertFalse(next.predictionResults.isEmpty, "\(testCase.acceptedText) の続きの予測が無い")
@@ -538,9 +538,11 @@ final class ZenzaiTests: XCTestCase {
                 )
             ]
         )
-        converter.setPrefixCandidate(accepted)
         var composingText = ComposingText()
-        composingText.insertAtCursorPosition("ひだり", inputStyle: .direct)
+        composingText.insertAtCursorPosition("ひだ", inputStyle: .direct)
+        _ = converter.requestCandidates(composingText, options: options)
+        XCTAssertTrue(converter.acceptPredictionCandidate(accepted, composingText: &composingText))
+        XCTAssertEqual(composingText.convertTarget, "ひだり")
 
         let result = converter.requestCandidates(composingText, options: options)
 
@@ -571,14 +573,15 @@ final class ZenzaiTests: XCTestCase {
         options.requireJapanesePrediction = .manualMix
         options.experimentalZenzaiPredictiveInput = false
         var composingText = ComposingText()
-        composingText.insertAtCursorPosition("きょう", inputStyle: .direct)
+        composingText.insertAtCursorPosition("きょ", inputStyle: .direct)
         let initialResult = converter.requestCandidates(composingText, options: options)
         let accepted = try XCTUnwrap(
             initialResult.predictionResults.first { $0.data.map(\.word).joined() == template }
         )
         XCTAssertTrue(initialResult.predictionResults.contains { $0.data.map(\.word).joined() == template + "は晴れ" })
 
-        converter.setPrefixCandidate(accepted)
+        XCTAssertTrue(converter.acceptPredictionCandidate(accepted, composingText: &composingText))
+        XCTAssertEqual(composingText.convertTarget, "きょう")
         let nextResult = converter.requestCandidates(composingText, options: options)
 
         XCTAssertFalse(nextResult.predictionResults.isEmpty)

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ZenzaiTests.swift
@@ -90,7 +90,7 @@ final class ZenzaiTests: XCTestCase {
         inferenceLimit: Int = Int.max,
         leftSideContext: String? = nil
     ) -> ConvertRequestOptions {
-        return .init(
+        .init(
             N_best: 10,
             requireJapanesePrediction: .disabled,
             requireEnglishPrediction: .disabled,
@@ -480,6 +480,52 @@ final class ZenzaiTests: XCTestCase {
                 )
             }
         }
+    }
+
+    func testPrefixCandidateConstrainsFollowingConversion() throws {
+        // 予測候補を受け入れたあと、その読みまで入力を伸ばして変換すると、
+        // 受け入れた候補の表記が第一候補になり、次の予測候補もその表記で始まる。
+        // 素の変換では `かみの` は `上の`、`ひだり` は `左` になる。
+        let dicdataStore = DicdataStore.withDefaultDictionary(preloadDictionary: true)
+        let options = self.desktopPredictiveInputOptions(leftSideContext: "")
+        struct TestCase {
+            var input: String
+            var acceptedRuby: String
+            var acceptedText: String
+        }
+        let testCases: [TestCase] = [
+            TestCase(input: "かみ", acceptedRuby: "かみの", acceptedText: "神の"),
+            TestCase(input: "ひだ", acceptedRuby: "ひだり", acceptedText: "←")
+        ]
+        for testCase in testCases {
+            let converter = KanaKanjiConverter(dicdataStore: dicdataStore)
+            var composingText = ComposingText()
+            composingText.insertAtCursorPosition(testCase.input, inputStyle: .direct)
+            let result = converter.requestCandidates(composingText, options: options)
+            // 受け入れる予測候補。`←` は `ひだ` の予測に出ないので、読み `ひだり` の変換候補から用意する
+            let accepted = try XCTUnwrap(
+                result.predictionResults.first { $0.text == testCase.acceptedText }
+                    ?? self.candidate(withText: testCase.acceptedText, ofRuby: testCase.acceptedRuby, dicdataStore: dicdataStore, options: options),
+                "\(testCase.acceptedText) が候補に無い"
+            )
+            converter.setPrefixCandidate(accepted)
+            composingText.insertAtCursorPosition(String(testCase.acceptedRuby.dropFirst(testCase.input.count)), inputStyle: .direct)
+            let next = converter.requestCandidates(composingText, options: options)
+            XCTAssertEqual(next.mainResults.first?.text, testCase.acceptedText, "\(testCase.input) → \(testCase.acceptedText)")
+            XCTAssertFalse(next.predictionResults.isEmpty, "\(testCase.acceptedText) の続きの予測が無い")
+            for prediction in next.predictionResults {
+                XCTAssertTrue(prediction.text.hasPrefix(testCase.acceptedText), "予測 \(prediction.text) が \(testCase.acceptedText) で始まらない")
+            }
+        }
+    }
+
+    private func candidate(withText text: String, ofRuby ruby: String, dicdataStore: DicdataStore, options: ConvertRequestOptions) -> Candidate? {
+        var composingText = ComposingText()
+        composingText.insertAtCursorPosition(ruby, inputStyle: .direct)
+        return KanaKanjiConverter(dicdataStore: dicdataStore)
+            .requestCandidates(composingText, options: options)
+            .mainResults
+            .first { $0.text == text }
     }
 
     @MainActor


### PR DESCRIPTION
Closes #356

背景は、issue #356 を参照してください

## レビュアーの方へ

私の手元ではとりあえず動き、予測変換が快適に使えているので、全く急いでいません。
余裕のある時に見ていただければと思います。
不具合の修正というより、予測変換機能の一部追加という位置付けだと思うので、構想と違ったらボツにしてください。

## 実装

API `KanaKanjiConverter.acceptPredictionCandidate(_:composingText:)` を追加しました。`ConversionResult.predictionResults` の候補と現在の `ComposingText` を渡すと、候補の残りの読みを未確定入力へ追加し、同時に候補を session の `ZenzaiCache` に保管します。候補の読みが現在の入力から伸びる場合にだけ適用し、適用できなければ `false` を返して入力・内部状態を変更しません。ローマ字入力などの未確定 suffix の置き換えも Converter 側で行います。

保管した候補は、その読みが入力の先頭に残っている間、表記を `PrefixConstraint` の先頭に固定します（`FixedPrefix`）。読みが先頭から消えたら捨てます。

固定した表記はモデルに採点させません。モデルが ← で読み ひだり を使い切ったと分かるように、`ZenzCandidateEvaluator.evaluate` では固定した表記を左文脈に移し、その読みを入力から除いて、残りだけを採点します。

予測候補も固定した表記で始まるように、以下を調整しました。

- 予測のもとにする変換候補と、後段で混ぜる予測候補の両方に prefix 制約を適用する。
- テンプレート候補は展開前の表記で prefix を照合しつつ、受理済みの展開結果を維持する。
- 固定範囲をまたぐ `DicdataElement` を失わないよう、境界上の候補データを保持する。
- 制約付きのラティス構築でも学習・ユーザ辞書のノードに固定した表記の長さまで制約を適用する。

`Candidate` に `Equatable` を追加しました（クライアントが予測候補の構造体に `Candidate` を持たせて比較できると便利なため）。

## 確認

- `swift test --filter PredictiveInputCacheTests`: 9 件、0 failures
- `swift test --traits Zenzai --filter ZenzaiTests.testPrefixCandidate`: 3 件、0 failures
- `swift test --traits Zenzai`: 201 件、0 failures
- azooKey-Desktop 側の試作で、ひだ → Tab（←）→ ←の の予測、`nimaga` と入力して ←に曲がる、を実機で確認しました。現在は Desktop 側で行っていた未確定入力の操作と固定処理を上記 API に統合しています。