### PR TITLE
feat: 自然な日数の読み・来週の曜日・月末から日付候補を生成する

### DIFF
--- a/Sources/KanaKanjiConverterModule/ConverterAPI/SpecialConversion/RelativeDateShortcuts.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/SpecialConversion/RelativeDateShortcuts.swift
@@ -1,0 +1,112 @@
+import Foundation
+import SwiftUtils
+
+enum RelativeDateShortcuts {
+    // 暦日の加算は最大10年程度に限定し、桁あふれや意図しない巨大な日付を避ける。
+    static let maximumDayOffset = 3660
+
+    static func date(matching ruby: String, now: Date = Date(), calendar: Calendar = .current) -> Date? {
+        let today = calendar.startOfDay(for: now)
+        if ruby == "ゲツマツ" {
+            guard let month = calendar.dateInterval(of: .month, for: today) else {
+                return nil
+            }
+            return calendar.date(byAdding: .day, value: -1, to: month.end)
+        }
+        let prefix = "ライシュウノ"
+        if ruby.hasPrefix(prefix) {
+            let weekdayReading = String(ruby.dropFirst(prefix.count))
+            let weekdays = ["ゲツヨウ", "カヨウ", "スイヨウ", "モクヨウ", "キンヨウ", "ドヨウ", "ニチヨウ"]
+            guard let weekday = weekdays.firstIndex(where: { weekdayReading == $0 || weekdayReading == $0 + "ビ" }) else {
+                return nil
+            }
+            // Calendar.firstWeekday（地域設定）によらず、月曜を週の始まりとする。
+            let daysSinceMonday = (calendar.component(.weekday, from: today) + 5) % 7
+            return calendar.date(byAdding: .day, value: 7 - daysSinceMonday + weekday, to: today)
+        }
+        guard let days = dayOffset(matching: ruby) else {
+            return nil
+        }
+        return calendar.date(byAdding: .day, value: days, to: today)
+    }
+
+    private static func dayOffset(matching ruby: String) -> Int? {
+        let suffix: String
+        let direction: Int
+        if ruby.hasSuffix("マエ") {
+            suffix = "マエ"
+            direction = -1
+        } else if ruby.hasSuffix("ゴ") {
+            suffix = "ゴ"
+            direction = 1
+        } else {
+            return nil
+        }
+        let reading = String(ruby.dropLast(suffix.count))
+        let naturalReadings = ["イチニチ", "フツカ", "ミッカ", "ヨッカ", "イツカ", "ムイカ", "ナノカ", "ヨウカ", "ココノカ", "トオカ"]
+        if let index = naturalReadings.firstIndex(of: reading) {
+            return direction * (index + 1)
+        }
+        guard reading.hasSuffix("ニチ") else {
+            return nil
+        }
+        let digits = reading.dropLast(2).unicodeScalars
+        guard !digits.isEmpty, digits.count <= 4 else {
+            return nil
+        }
+        var days = 0
+        for scalar in digits {
+            let value: UInt32
+            switch scalar.value {
+            case 0x30...0x39: value = scalar.value - 0x30
+            case 0xFF10...0xFF19: value = scalar.value - 0xFF10
+            default: return nil
+            }
+            days = days * 10 + Int(value)
+        }
+        guard days <= maximumDayOffset else {
+            return nil
+        }
+        return direction * days
+    }
+
+    static func candidates(_ inputData: ComposingText, now: Date = Date(), calendar: Calendar = .current) -> [Candidate] {
+        guard inputData.convertTargetCursorPosition == inputData.convertTarget.count else {
+            return []
+        }
+        let ruby = inputData.convertTarget.toKatakana()
+        guard let date = date(matching: ruby, now: now, calendar: calendar) else {
+            return []
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.timeZone = calendar.timeZone
+        return formats.map { format in
+            formatter.calendar = Calendar(identifier: format.calendar)
+            formatter.dateFormat = format.pattern
+            let text = formatter.string(from: date)
+            return Candidate(
+                text: text, value: format.value,
+                composingCount: .inputCount(inputData.input.count), lastMid: MIDData.一般.mid,
+                data: [DicdataElement(word: text, ruby: ruby, cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: format.value)],
+                isLearningTarget: false
+            )
+        }
+    }
+
+    private struct Format: Sendable {
+        let pattern: String
+        let value: PValue
+        let calendar: Calendar.Identifier
+    }
+
+    private static let formats: [Format] = [
+        .init(pattern: "M/d", value: -18, calendar: .gregorian),
+        .init(pattern: "yyyy/MM/dd", value: -18.1, calendar: .gregorian),
+        .init(pattern: "yyyy-MM-dd", value: -18.2, calendar: .gregorian),
+        .init(pattern: "M月d日（E）", value: -18.3, calendar: .gregorian),
+        .init(pattern: "yyyy年M月d日", value: -18.4, calendar: .gregorian),
+        .init(pattern: "Gy年M月d日", value: -18.5, calendar: .japanese),
+        .init(pattern: "E曜日", value: -18.6, calendar: .gregorian)
+    ]
+}

--- a/Sources/KanaKanjiConverterModule/ConverterAPI/SpecialConversion/SpecialCandidateProvider.swift
+++ b/Sources/KanaKanjiConverterModule/ConverterAPI/SpecialConversion/SpecialCandidateProvider.swift
@@ -5,7 +5,7 @@ public protocol SpecialCandidateProvider: Sendable {
 public struct CalendarSpecialCandidateProvider: SpecialCandidateProvider {
     public init() {}
     public func provideCandidates(converter: KanaKanjiConverter, inputData: ComposingText, options _: ConvertRequestOptions) -> [Candidate] {
-        converter.toWarekiCandidates(inputData) + converter.toSeirekiCandidates(inputData)
+        converter.toWarekiCandidates(inputData) + converter.toSeirekiCandidates(inputData) + RelativeDateShortcuts.candidates(inputData)
     }
 }
 

--- a/Tests/KanaKanjiConverterModuleTests/ConverterAPI/RelativeDateShortcutsTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterAPI/RelativeDateShortcutsTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+@testable import KanaKanjiConverterModule
+import Testing
+
+@Suite("Relative date shortcuts")
+struct RelativeDateShortcutsTests {
+    private func calendar(_ zone: String = "Asia/Tokyo") -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: zone)!
+        return calendar
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12, calendar: Calendar) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+
+    @Test func nextWeekStartsOnMondayForEveryCurrentWeekday() {
+        var calendar = calendar()
+        calendar.firstWeekday = 1
+        let readings = ["ゲツヨウ", "カヨウ", "スイヨウ", "モクヨウ", "キンヨウ", "ドヨウ", "ニチヨウ"]
+        for currentDay in 7...13 {
+            let now = date(2026, 9, currentDay, calendar: calendar)
+            for (index, reading) in readings.enumerated() {
+                for suffix in ["", "ビ"] {
+                    let actual = RelativeDateShortcuts.date(matching: "ライシュウノ" + reading + suffix, now: now, calendar: calendar)
+                    #expect(actual == date(2026, 9, 14 + index, hour: 0, calendar: calendar))
+                }
+            }
+        }
+    }
+
+    @Test(arguments: [(2026, 2, 15, 28), (2028, 2, 15, 29), (2026, 4, 30, 30), (2026, 12, 31, 31)])
+    func monthEnd(year: Int, month: Int, day: Int, lastDay: Int) {
+        let calendar = calendar()
+        let actual = RelativeDateShortcuts.date(matching: "ゲツマツ", now: date(year, month, day, calendar: calendar), calendar: calendar)
+        #expect(actual == date(year, month, lastDay, hour: 0, calendar: calendar))
+    }
+
+    @Test func dayOffsets() {
+        let cases = [
+            (2026, 9, 30, "3ニチゴ", 2026, 10, 3),
+            (2026, 12, 31, "１ニチゴ", 2027, 1, 1),
+            (2028, 2, 28, "1ニチゴ", 2028, 2, 29),
+            (2026, 9, 5, "0ニチゴ", 2026, 9, 5),
+            (2026, 9, 5, "０1ニチゴ", 2026, 9, 6),
+            (2026, 9, 5, "０００３ニチゴ", 2026, 9, 8)
+        ]
+        let calendar = calendar()
+        for (year, month, day, reading, targetYear, targetMonth, targetDay) in cases {
+            let actual = RelativeDateShortcuts.date(matching: reading, now: date(year, month, day, calendar: calendar), calendar: calendar)
+            #expect(actual == date(targetYear, targetMonth, targetDay, hour: 0, calendar: calendar))
+        }
+    }
+
+    @Test func naturalReadingsInBothDirections() {
+        let calendar = calendar()
+        let now = date(2028, 3, 1, calendar: calendar)
+        let readings = ["イチニチ", "フツカ", "ミッカ", "ヨッカ", "イツカ", "ムイカ", "ナノカ", "ヨウカ", "ココノカ", "トオカ"]
+        for (index, reading) in readings.enumerated() {
+            for (suffix, direction) in [("ゴ", 1), ("マエ", -1)] {
+                let expected = calendar.date(byAdding: .day, value: direction * (index + 1), to: calendar.startOfDay(for: now))
+                #expect(RelativeDateShortcuts.date(matching: reading + suffix, now: now, calendar: calendar) == expected)
+            }
+        }
+        #expect(RelativeDateShortcuts.date(matching: "イチニチマエ", now: now, calendar: calendar) == date(2028, 2, 29, hour: 0, calendar: calendar))
+    }
+
+    @Test func numericPastAndDaylightSaving() {
+        let calendar = calendar("America/Los_Angeles")
+        let now = date(2026, 3, 9, hour: 23, calendar: calendar)
+        for reading in ["2ニチマエ", "２ニチマエ", "フツカマエ"] {
+            #expect(RelativeDateShortcuts.date(matching: reading, now: now, calendar: calendar) == date(2026, 3, 7, hour: 0, calendar: calendar))
+        }
+        #expect(RelativeDateShortcuts.date(matching: "3660ニチマエ", now: now, calendar: calendar) == calendar.date(byAdding: .day, value: -3660, to: calendar.startOfDay(for: now)))
+    }
+
+    @Test func maximumOffsetAndYearBoundary() {
+        let calendar = calendar()
+        let now = date(2026, 12, 31, calendar: calendar)
+        #expect(RelativeDateShortcuts.date(matching: "3660ニチゴ", now: now, calendar: calendar) == calendar.date(byAdding: .day, value: 3660, to: calendar.startOfDay(for: now)))
+        #expect(RelativeDateShortcuts.date(matching: "ライシュウノゲツヨウ", now: now, calendar: calendar) == date(2027, 1, 4, hour: 0, calendar: calendar))
+    }
+
+    @Test(arguments: [(2026, 3, 7, 9), (2026, 10, 31, 2)])
+    func daylightSaving(year: Int, month: Int, day: Int, targetDay: Int) {
+        let calendar = calendar("America/Los_Angeles")
+        let now = date(year, month, day, hour: 23, calendar: calendar)
+        let targetMonth = month == 10 ? 11 : month
+        let target = date(year, targetMonth, targetDay, hour: 0, calendar: calendar)
+        #expect(RelativeDateShortcuts.date(matching: "2ニチゴ", now: now, calendar: calendar) == target)
+        #expect(RelativeDateShortcuts.date(matching: "ライシュウノゲツヨウ", now: now, calendar: calendar) == target)
+    }
+
+    @Test func sevenExistingFormats() {
+        let calendar = calendar()
+        let elements = self.elements("3ニチゴ", now: date(2026, 9, 5, calendar: calendar), calendar: calendar)
+        #expect(elements.map(\.text) == ["9/8", "2026/09/08", "2026-09-08", "9月8日（火）", "2026年9月8日", "令和8年9月8日", "火曜日"])
+        #expect(elements.allSatisfy { $0.data.allSatisfy { $0.ruby == "3ニチゴ" } })
+    }
+
+    @Test(arguments: ["", "ゲツヨウ", "ゲツヨウビ", "キョウ", "ライシュウ", "ライシュウノゲツ", "ライシュウノゲツヨウニ", "ゲツマツニ", "ニチゴ", "-1ニチゴ", "+1ニチゴ", "1.5ニチゴ", "٣ニチゴ", "③ニチゴ", "三ニチゴ", "3661ニチゴ", "999999999999ニチゴ", "00001ニチゴ", "3ニチゴニ", "アト3ニチゴ", "ミッカ", "ミッカゴニ", "ミッカマエニ", "ゴ", "マエ", "ニチマエ", "3661ニチマエ", "-1ニチマエ", "00001ニチマエ"])
+    func requiresWholeSupportedReading(_ reading: String) {
+        #expect(elements(reading).isEmpty)
+    }
+
+    @Test(arguments: ["futsukago", "mikkago", "yokkago", "futsukamae", "mikkamae"])
+    func romanInputRange(_ input: String) throws {
+        var composing = ComposingText()
+        composing.insertAtCursorPosition(input, inputStyle: .roman2kana)
+        let candidates = RelativeDateShortcuts.candidates(composing)
+        #expect(candidates.count == 7)
+        #expect(candidates.allSatisfy { !$0.isLearningTarget && $0.composingCount == .inputCount(composing.input.count) })
+        _ = composing.moveCursorFromCursorPosition(count: -1)
+        #expect(RelativeDateShortcuts.candidates(composing).isEmpty)
+    }
+
+    @Test func calendarProviderIncludesRelativeDates() {
+        let converter = KanaKanjiConverter.withoutDictionary()
+        var input = ComposingText()
+        input.insertAtCursorPosition("みっかまえ", inputStyle: .direct)
+        let candidates = CalendarSpecialCandidateProvider().provideCandidates(converter: converter, inputData: input, options: .default)
+        #expect(candidates.count == 7)
+        #expect(candidates.allSatisfy { !$0.isLearningTarget })
+    }
+
+    private func elements(_ reading: String, now: Date = Date(), calendar: Calendar = .current) -> [Candidate] {
+        var input = ComposingText()
+        input.insertAtCursorPosition(reading, inputStyle: .direct)
+        return RelativeDateShortcuts.candidates(input, now: now, calendar: calendar)
+    }
+}


### PR DESCRIPTION
「ふつかご」「みっかまえ」「らいしゅうのげつよう」「げつまつ」などを、現在日付から計算した日付候補に変換します。既存の `CalendarSpecialCandidateProvider` に組み込み、デフォルトの特殊候補として利用できます。

## 対応する読み

- 「いちにち・ふつか・みっか・よっか・いつか・むいか・なのか・ようか・ここのか・とおか」＋「ご／まえ」
- 数字の「3にちご」「３にちまえ」など（前後0〜3660日、半角・全角数字、数字部分は最大4桁）
- 「らいしゅうのげつよう（び）」など全曜日。月曜始まりの次週として計算
- 「げつまつ」：今月の最終日

たとえば2026年9月5日に「みっかご」を変換すると、`9/8`、`2026/09/08`、`2026-09-08`、`9月8日（火）`、`2026年9月8日`、`令和8年9月8日`、`火曜日` を生成します。

読み全体が一致するときのみ生成し、カーソルが末尾にない場合は全入力の日付候補を追加しません。入力キー数で消費範囲を指定し、日付候補は学習対象外にしています。日数の加減算は Calendar の暦日単位で行います。

## 検証

- `swift test --jobs 4 --filter KanaKanjiConverterModuleTests`：既存XCTest 113件＋相対日付Swift Testing 11件が成功
- 自然読みの前後、数字・上限・不正入力、週/月/年境界、うるう年、DST、7書式、ローマ字入力の消費範囲、カレンダープロバイダーへの接続を確認
- 追加2ファイルのSwiftLint、`git diff --check` 成功
- 全体テストも開始しましたが、辞書の変換精度評価が長時間かかるため中断しました。全体テスト完走は未確認です。

azooKey/azooKey-Desktop#369 でいただいた、変換エンジン側に実装する方針に合わせた提案です。
